### PR TITLE
[FEAT/#7] 공통 컴포넌트 구현 - 텍스트필드, 다이얼로그, 선택버튼, 드롭다운

### DIFF
--- a/app/src/main/java/com/konkuk/strhat/core/component/bottomsheet/YearPickerBottomSheet.kt
+++ b/app/src/main/java/com/konkuk/strhat/core/component/bottomsheet/YearPickerBottomSheet.kt
@@ -157,7 +157,7 @@ private fun SelectableButton(
             Text(
                 text = if (selectedYear == 0) "${currentYear}년" else "${selectedYear}년",
                 color = if (selectedYear == 0) colors.Gray400 else colors.MainBlack,
-                style = typography.head2_b_20
+                style = typography.body1_m_16
             )
             Icon(
                 imageVector = ImageVector.vectorResource(id = R.drawable.ic_arrow_dropdown_down),

--- a/app/src/main/java/com/konkuk/strhat/core/component/bottomsheet/YearPickerBottomSheet.kt
+++ b/app/src/main/java/com/konkuk/strhat/core/component/bottomsheet/YearPickerBottomSheet.kt
@@ -30,6 +30,7 @@ import com.konkuk.strhat.core.component.bottomsheet.draghandle.BottomSheetDragHa
 import com.konkuk.strhat.core.component.button.StrHatButton
 import com.konkuk.strhat.core.component.picker.Picker
 import com.konkuk.strhat.core.component.picker.PickerState
+import com.konkuk.strhat.core.util.KeyStorage.MIN_YEAR
 import com.konkuk.strhat.core.util.modifier.noRippleClickable
 import com.konkuk.strhat.ui.theme.StrHatTheme.colors
 import com.konkuk.strhat.ui.theme.StrHatTheme.typography
@@ -81,7 +82,7 @@ private fun YearSelectionBottomSheet(
     onYearSelected: (Int) -> Unit
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    val years = remember { (2000..currentYear).toList() }
+    val years = remember { (MIN_YEAR..currentYear).toList() }
     val defaultYearIndex = years.indexOf(
         if (selectedYear == 0) currentYear else selectedYear
     ).takeIf { it >= 0 } ?: 0

--- a/app/src/main/java/com/konkuk/strhat/core/component/bottomsheet/YearPickerBottomSheet.kt
+++ b/app/src/main/java/com/konkuk/strhat/core/component/bottomsheet/YearPickerBottomSheet.kt
@@ -28,8 +28,8 @@ import androidx.compose.ui.unit.dp
 import com.konkuk.strhat.R
 import com.konkuk.strhat.core.component.bottomsheet.draghandle.BottomSheetDragHandle
 import com.konkuk.strhat.core.component.button.StrHatButton
-import com.konkuk.strhat.core.component.picker.Picker
 import com.konkuk.strhat.core.component.picker.PickerState
+import com.konkuk.strhat.core.component.picker.YearPicker
 import com.konkuk.strhat.core.util.KeyStorage.MIN_YEAR
 import com.konkuk.strhat.core.util.modifier.noRippleClickable
 import com.konkuk.strhat.ui.theme.StrHatTheme.colors
@@ -79,7 +79,8 @@ private fun YearSelectionBottomSheet(
     selectedYear: Int,
     currentYear: Int,
     onDismiss: () -> Unit,
-    onYearSelected: (Int) -> Unit
+    onYearSelected: (Int) -> Unit,
+    modifier: Modifier = Modifier
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val years = remember { (MIN_YEAR..currentYear).toList() }
@@ -94,7 +95,7 @@ private fun YearSelectionBottomSheet(
     }
 
     ModalBottomSheet(
-        modifier = Modifier,
+        modifier = modifier,
         containerColor = colors.MainWhite,
         onDismissRequest = onDismiss,
         sheetState = sheetState,
@@ -113,9 +114,9 @@ private fun YearSelectionBottomSheet(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(top = 40.dp, bottom = 20.dp)
-                    .padding(horizontal = 33.dp)
+                    .padding(horizontal = 32.dp)
             ) {
-                Picker(
+                YearPicker(
                     state = pickerState,
                     items = years.map { it.toString() },
                     initialSelectedIndex = defaultYearIndex,
@@ -139,7 +140,8 @@ private fun YearSelectionBottomSheet(
 private fun SelectableButton(
     selectedYear: Int,
     currentYear: Int,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
     Box(
         modifier = Modifier
@@ -153,7 +155,7 @@ private fun SelectableButton(
             .padding(vertical = 12.dp, horizontal = 16.dp)
     ) {
         Row(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {

--- a/app/src/main/java/com/konkuk/strhat/core/component/bottomsheet/YearPickerBottomSheet.kt
+++ b/app/src/main/java/com/konkuk/strhat/core/component/bottomsheet/YearPickerBottomSheet.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.konkuk.strhat.R
+import com.konkuk.strhat.core.component.bottomsheet.draghandle.BottomSheetDragHandle
 import com.konkuk.strhat.core.component.button.StrHatButton
 import com.konkuk.strhat.core.component.picker.Picker
 import com.konkuk.strhat.core.component.picker.PickerState
@@ -95,7 +96,8 @@ private fun YearSelectionBottomSheet(
         modifier = Modifier,
         containerColor = colors.MainWhite,
         onDismissRequest = onDismiss,
-        sheetState = sheetState
+        sheetState = sheetState,
+        dragHandle = { BottomSheetDragHandle() }
     ) {
         Column(
             modifier = Modifier.padding(horizontal = 16.dp, vertical = 28.dp)

--- a/app/src/main/java/com/konkuk/strhat/core/component/bottomsheet/YearPickerBottomSheet.kt
+++ b/app/src/main/java/com/konkuk/strhat/core/component/bottomsheet/YearPickerBottomSheet.kt
@@ -1,0 +1,178 @@
+package com.konkuk.strhat.core.component.bottomsheet
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.konkuk.strhat.R
+import com.konkuk.strhat.core.component.button.StrHatButton
+import com.konkuk.strhat.core.component.picker.Picker
+import com.konkuk.strhat.core.component.picker.PickerState
+import com.konkuk.strhat.core.util.modifier.noRippleClickable
+import com.konkuk.strhat.ui.theme.StrHatTheme.colors
+import com.konkuk.strhat.ui.theme.StrHatTheme.typography
+import java.util.Calendar
+
+@Composable
+fun YearSelectableButton(
+    selectedYear: Int,
+    onYearSelected: (Int) -> Unit
+) {
+    var showBottomSheet by remember { mutableStateOf(false) }
+    val currentYear = Calendar.getInstance().get(Calendar.YEAR)
+
+    Column(
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.year_picker_title),
+            color = colors.MainBlack,
+            style = typography.title1_b_18
+        )
+
+        SelectableButton(
+            selectedYear = selectedYear,
+            currentYear = currentYear,
+            onClick = { showBottomSheet = true }
+        )
+
+        if (showBottomSheet) {
+            YearSelectionBottomSheet(
+                selectedYear = selectedYear,
+                currentYear = currentYear,
+                onDismiss = { showBottomSheet = false },
+                onYearSelected = {
+                    onYearSelected(it)
+                    showBottomSheet = false
+                }
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun YearSelectionBottomSheet(
+    selectedYear: Int,
+    currentYear: Int,
+    onDismiss: () -> Unit,
+    onYearSelected: (Int) -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val years = remember { (2000..currentYear).toList() }
+    val defaultYearIndex = years.indexOf(
+        if (selectedYear == 0) currentYear else selectedYear
+    ).takeIf { it >= 0 } ?: 0
+
+    val pickerState = remember {
+        PickerState().apply {
+            selectedItem = years[defaultYearIndex].toString()
+        }
+    }
+
+    ModalBottomSheet(
+        modifier = Modifier,
+        containerColor = colors.MainWhite,
+        onDismissRequest = onDismiss,
+        sheetState = sheetState
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 28.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.year_picker_bottom_sheet_title),
+                style = typography.title1_b_18,
+                color = colors.MainBlack
+            )
+
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 40.dp, bottom = 20.dp)
+                    .padding(horizontal = 33.dp)
+            ) {
+                Picker(
+                    state = pickerState,
+                    items = years.map { it.toString() },
+                    initialSelectedIndex = defaultYearIndex,
+                    textModifier = Modifier.padding(vertical = 16.dp)
+                )
+            }
+
+            StrHatButton(
+                text = stringResource(R.string.year_picker_bottom_sheet_button),
+                isDisabled = false,
+                onClick = {
+                    val selectedYearValue = pickerState.selectedItem.toIntOrNull() ?: currentYear
+                    onYearSelected(selectedYearValue)
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun SelectableButton(
+    selectedYear: Int,
+    currentYear: Int,
+    onClick: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .noRippleClickable { onClick() }
+            .border(
+                width = 1.dp,
+                color = colors.Gray400,
+                shape = RoundedCornerShape(6.dp)
+            )
+            .padding(vertical = 12.dp, horizontal = 16.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = if (selectedYear == 0) "${currentYear}년" else "${selectedYear}년",
+                color = if (selectedYear == 0) colors.Gray400 else colors.MainBlack,
+                style = typography.head2_b_20
+            )
+            Icon(
+                imageVector = ImageVector.vectorResource(id = R.drawable.ic_arrow_dropdown_down),
+                contentDescription = null,
+                tint = colors.MainBlack
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewYearSelectableButton() {
+    YearSelectableButton(
+        selectedYear = 0,
+        onYearSelected = {}
+    )
+}

--- a/app/src/main/java/com/konkuk/strhat/core/component/button/StrHatSelectableButton.kt
+++ b/app/src/main/java/com/konkuk/strhat/core/component/button/StrHatSelectableButton.kt
@@ -21,7 +21,6 @@ import com.konkuk.strhat.core.util.modifier.noRippleClickable
 import com.konkuk.strhat.ui.theme.StrHatTheme
 import com.konkuk.strhat.ui.theme.StrHatTheme.colors
 import com.konkuk.strhat.ui.theme.StrHatTheme.typography
-import com.konkuk.strhat.ui.theme.SubBlue
 
 @Composable
 fun StrHatSelectableButtons(
@@ -54,7 +53,7 @@ fun StrHatSelectableButton(
     Box(
         modifier = modifier
             .background(
-                color = if (isSelected) SubBlue else colors.Gray100,
+                color = if (isSelected) colors.SubBlue else colors.Gray100,
                 shape = RoundedCornerShape(6.dp)
             )
             .noRippleClickable(onClick = onClick)

--- a/app/src/main/java/com/konkuk/strhat/core/component/button/StrHatSelectableButton.kt
+++ b/app/src/main/java/com/konkuk/strhat/core/component/button/StrHatSelectableButton.kt
@@ -1,0 +1,87 @@
+package com.konkuk.strhat.core.component.button
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.konkuk.strhat.core.util.modifier.noRippleClickable
+import com.konkuk.strhat.ui.theme.StrHatTheme
+import com.konkuk.strhat.ui.theme.StrHatTheme.colors
+import com.konkuk.strhat.ui.theme.StrHatTheme.typography
+import com.konkuk.strhat.ui.theme.SubBlue
+
+@Composable
+fun StrHatSelectableButtons(
+    options: List<String>,
+    onOptionSelected: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    selectedOption: String? = null
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(20.dp)
+    ) {
+        options.forEach { option ->
+            StrHatSelectableButton(
+                option = option,
+                onClick = { onOptionSelected(option) },
+                isSelected = option == selectedOption
+            )
+        }
+    }
+}
+
+@Composable
+fun StrHatSelectableButton(
+    option: String,
+    onClick: () -> Unit,
+    isSelected: Boolean,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .background(
+                color = if (isSelected) SubBlue else colors.Gray100,
+                shape = RoundedCornerShape(6.dp)
+            )
+            .noRippleClickable(onClick = onClick)
+            .fillMaxWidth(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = option,
+            modifier = Modifier.padding(vertical = 14.dp),
+            color = if (isSelected) colors.MainBlue else colors.Gray500,
+            style = typography.body1_r_16
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewStrHatSelectableButton() {
+    val options = listOf(
+        "남성", "여성"
+    )
+    var selectedOption by remember { mutableStateOf("") }
+    StrHatTheme {
+        StrHatSelectableButtons(
+            options = options,
+            onOptionSelected = { option -> selectedOption = option },
+            selectedOption = selectedOption
+        )
+    }
+}

--- a/app/src/main/java/com/konkuk/strhat/core/component/dialog/StrHatDialog.kt
+++ b/app/src/main/java/com/konkuk/strhat/core/component/dialog/StrHatDialog.kt
@@ -1,0 +1,200 @@
+package com.konkuk.strhat.core.component.dialog
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.konkuk.strhat.R
+import com.konkuk.strhat.core.component.button.StrHatButton
+import com.konkuk.strhat.ui.theme.StrHatTheme.colors
+import com.konkuk.strhat.ui.theme.StrHatTheme.typography
+
+@Composable
+fun StrHatDialog(
+    titleResId: Int,
+    imageResId: Int? = null,
+    imageRatio: Float? = null,
+    descriptionResId: Int? = null,
+    diary: String? = null,
+    onConfirmButtonClick: () -> Unit,
+    onDismissButtonClick: () -> Unit = {},
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = Modifier
+            .padding(horizontal = 15.dp)
+            .background(color = colors.MainWhite, shape = RoundedCornerShape(20.dp))
+            .padding(20.dp)
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Image(
+                imageVector = ImageVector.vectorResource(R.drawable.ic_logo_blue),
+                contentDescription = null,
+                modifier = Modifier
+                    .padding(end = 15.dp)
+                    .size(40.dp)
+            )
+
+            Text(
+                text = stringResource(titleResId),
+                style = typography.title1_b_18,
+                color = colors.MainBlack
+            )
+        }
+
+        if (imageResId != null && imageRatio != null && descriptionResId != null) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.padding(vertical = 20.dp)
+            ) {
+                Image(
+                    imageVector = ImageVector.vectorResource(imageResId),
+                    contentDescription = null,
+                    modifier = modifier
+                        .padding(bottom = 20.dp)
+                        .aspectRatio(imageRatio)
+                )
+
+                Text(
+                    text = stringResource(descriptionResId),
+                    style = typography.body3_m_14,
+                    color = colors.Gray600
+                )
+            }
+
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(20.dp)
+            ) {
+                StrHatButton(
+                    isDisabled = true,
+                    text = stringResource(R.string.dismiss),
+                    modifier = Modifier.weight(1f),
+                    onClick = onDismissButtonClick
+                )
+
+                StrHatButton(
+                    isDisabled = false,
+                    text = stringResource(R.string.confirm),
+                    modifier = Modifier.weight(1f),
+                    onClick = onConfirmButtonClick
+                )
+            }
+        } else if (diary != null) {
+            Column(
+                modifier = Modifier
+                    .padding(vertical = 20.dp)
+                    .background(
+                        color = colors.Gray100,
+                        shape = RoundedCornerShape(4.dp)
+                    )
+                    .height(LocalConfiguration.current.screenHeightDp.dp * 0.37f)
+                    .padding(15.dp)
+                    .verticalScroll(rememberScrollState())
+            ) {
+                Text(
+                    text = diary,
+                    style = typography.body2_r_15,
+                    color = colors.MainBlack
+                )
+            }
+
+            StrHatButton(
+                isDisabled = false,
+                text = stringResource(R.string.confirm),
+                onClick = onConfirmButtonClick
+            )
+        }
+
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewLogoutDialog() {
+    Box(
+        modifier = Modifier
+            .background(color = colors.MainWhite)
+            .fillMaxSize()
+    ) {
+        Dialog(
+            onDismissRequest = {}
+        ) {
+            StrHatDialog(
+                titleResId = R.string.dialog_logout_title,
+                imageResId = R.drawable.ic_strhat_dialog_all,
+                imageRatio = 2f / 1f,
+                descriptionResId = R.string.dialog_logout_description,
+                onConfirmButtonClick = {},
+                onDismissButtonClick = {}
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewChatDialog() {
+    Box(
+        modifier = Modifier
+            .background(color = colors.MainWhite)
+            .fillMaxSize()
+    ) {
+        Dialog(
+            onDismissRequest = {}
+        ) {
+            StrHatDialog(
+                titleResId = R.string.dialog_chat_title,
+                imageResId = R.drawable.ic_strhat_dialog_yellow_red_green,
+                imageRatio = 1f / 1f,
+                descriptionResId = R.string.dialog_chat_description,
+                onConfirmButtonClick = {},
+                onDismissButtonClick = {},
+                modifier = Modifier.padding(horizontal = 40.dp)
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewDiaryDialog() {
+    Box(
+        modifier = Modifier
+            .background(color = colors.MainWhite)
+            .fillMaxSize()
+    ) {
+        Dialog(
+            onDismissRequest = {}
+        ) {
+            StrHatDialog(
+                titleResId = R.string.dialog_diary_title,
+                diary = stringResource(R.string.textfield_diary),
+                onConfirmButtonClick = {},
+                modifier = Modifier.padding(horizontal = 40.dp)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/konkuk/strhat/core/component/dropdown/JobDropDown.kt
+++ b/app/src/main/java/com/konkuk/strhat/core/component/dropdown/JobDropDown.kt
@@ -1,0 +1,148 @@
+package com.konkuk.strhat.core.component.dropdown
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.konkuk.strhat.R
+import com.konkuk.strhat.core.util.color.setDropDownMenuTextStyle
+import com.konkuk.strhat.core.util.modifier.noRippleClickable
+import com.konkuk.strhat.domain.type.JobType
+import com.konkuk.strhat.ui.theme.StrHatTheme.colors
+import com.konkuk.strhat.ui.theme.StrHatTheme.typography
+
+@Composable
+fun JobDropDown(
+    onJobSelected: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var isDropDownMenuExpanded by remember { mutableStateOf(false) }
+    var selectedJob by remember { mutableStateOf(JobType.STUDENT.type) }
+
+    Column {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .noRippleClickable { isDropDownMenuExpanded = !isDropDownMenuExpanded }
+                .border(
+                    width = 1.dp,
+                    color = if (isDropDownMenuExpanded) colors.MainBlue else colors.Gray400,
+                    shape = RoundedCornerShape(6.dp)
+                )
+                .padding(vertical = 12.dp, horizontal = 16.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = selectedJob,
+                    color = colors.MainBlack,
+                    style = typography.body1_m_16
+                )
+                if (isDropDownMenuExpanded) {
+                    Icon(
+                        imageVector = ImageVector.vectorResource(id = R.drawable.ic_arrow_dropdown_up),
+                        contentDescription = null,
+                        tint = colors.MainBlack
+                    )
+                } else {
+                    Icon(
+                        imageVector = ImageVector.vectorResource(id = R.drawable.ic_arrow_dropdown_down),
+                        contentDescription = null,
+                        tint = colors.MainBlack
+                    )
+                }
+            }
+        }
+
+        DropdownMenu(
+            expanded = isDropDownMenuExpanded,
+            onDismissRequest = { isDropDownMenuExpanded = false },
+            modifier = modifier
+                .background(color = colors.MainWhite)
+                .fillMaxWidth()
+        ) {
+            DropdownMenuItem(
+                text = {
+                    val style = setDropDownMenuTextStyle(selectedJob, JobType.STUDENT.type)
+                    Text(
+                        text = JobType.STUDENT.type,
+                        color = style.color,
+                        style = style.typography
+                    )
+                },
+                onClick = {
+                    selectedJob = JobType.STUDENT.type
+                    onJobSelected(JobType.STUDENT.type)
+                    isDropDownMenuExpanded = false
+                }
+            )
+            DropdownMenuItem(
+                text = {
+                    val style = setDropDownMenuTextStyle(selectedJob, JobType.JOBSEEKER.type)
+                    Text(
+                        text = JobType.JOBSEEKER.type,
+                        color = style.color,
+                        style = style.typography
+                    )
+                },
+                onClick = {
+                    selectedJob = JobType.JOBSEEKER.type
+                    onJobSelected(JobType.JOBSEEKER.type)
+                    isDropDownMenuExpanded = false
+                }
+            )
+            DropdownMenuItem(
+                text = {
+                    val style = setDropDownMenuTextStyle(selectedJob, JobType.WORKER.type)
+                    Text(
+                        text = JobType.WORKER.type,
+                        color = style.color,
+                        style = style.typography
+                    )
+                },
+                onClick = {
+                    selectedJob = JobType.WORKER.type
+                    onJobSelected(JobType.WORKER.type)
+                    isDropDownMenuExpanded = false
+                }
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewJobDropDown() {
+    Column(
+        modifier = Modifier
+            .background(color = colors.MainWhite)
+            .fillMaxSize()
+    ) {
+        JobDropDown(onJobSelected = {})
+    }
+
+}

--- a/app/src/main/java/com/konkuk/strhat/core/component/picker/Picker.kt
+++ b/app/src/main/java/com/konkuk/strhat/core/component/picker/Picker.kt
@@ -1,0 +1,128 @@
+package com.konkuk.strhat.core.component.picker
+
+import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import com.konkuk.strhat.R
+import com.konkuk.strhat.ui.theme.StrHatTheme.colors
+import com.konkuk.strhat.ui.theme.StrHatTheme.typography
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.mapNotNull
+
+@Composable
+fun Picker(
+    items: List<String>,
+    modifier: Modifier = Modifier,
+    state: PickerState = rememberPickerState(),
+    initialSelectedIndex: Int = 0,
+    visibleItemsCount: Int = 3,
+    textModifier: Modifier = Modifier
+) {
+    val visibleItemsMiddle = visibleItemsCount / 2
+    val paddedItems =
+        remember(items) { List(visibleItemsMiddle) { "" } + items + List(visibleItemsMiddle) { "" } }
+    val listState = rememberLazyListState()
+    val flingBehavior = rememberSnapFlingBehavior(lazyListState = listState)
+    var itemHeightPixels by remember { mutableIntStateOf(0) }
+    val itemHeightDp = pixelsToDp(itemHeightPixels)
+    val centerIndex by remember { derivedStateOf { listState.firstVisibleItemIndex + visibleItemsMiddle } }
+
+    LaunchedEffect(initialSelectedIndex) {
+        listState.scrollToItem(initialSelectedIndex + visibleItemsMiddle)
+        state.selectedItem = items[initialSelectedIndex]
+    }
+
+    LaunchedEffect(listState) {
+        snapshotFlow { centerIndex - visibleItemsMiddle }
+            .mapNotNull { index -> items.getOrNull(index) }
+            .distinctUntilChanged()
+            .collect { state.selectedItem = it }
+    }
+
+    Box(modifier = modifier) {
+        GuideLines(
+            visibleItemsCount = visibleItemsCount,
+            itemHeightDp = itemHeightDp
+        )
+
+        LazyColumn(
+            state = listState,
+            flingBehavior = flingBehavior,
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .height(itemHeightDp * visibleItemsCount)
+                .fillMaxWidth()
+        ) {
+            items(paddedItems.size) { index ->
+                PickerItem(
+                    text = paddedItems[index],
+                    isSelected = index == centerIndex,
+                    onSizeChanged = { itemHeightPixels = it.height },
+                    modifier = textModifier
+                )
+            }
+        }
+
+        Text(
+            text = stringResource(R.string.year_picker_bottom_sheet),
+            color = colors.MainBlack,
+            style = typography.head2_r_20,
+            modifier = modifier
+                .align(Alignment.CenterEnd)
+                .padding(end = 16.dp)
+        )
+    }
+}
+
+@Composable
+private fun PickerItem(
+    text: String,
+    isSelected: Boolean,
+    onSizeChanged: (IntSize) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Text(
+        text = text,
+        maxLines = 1,
+        color = if (isSelected) colors.MainBlack else colors.Gray500,
+        style = if (isSelected) typography.head2_b_20 else typography.head2_r_20,
+        modifier = Modifier
+            .onSizeChanged { size -> onSizeChanged(size) }
+            .then(modifier)
+            .semantics {
+                if (isSelected) {
+                    selected = true
+                    stateDescription = "Selected"
+                }
+            }
+    )
+}
+
+@Composable
+private fun rememberPickerState() = remember { PickerState() }
+
+@Composable
+private fun pixelsToDp(pixels: Int) = with(LocalDensity.current) { pixels.toDp() }

--- a/app/src/main/java/com/konkuk/strhat/core/component/picker/PickerSelectedGuideLines.kt
+++ b/app/src/main/java/com/konkuk/strhat/core/component/picker/PickerSelectedGuideLines.kt
@@ -1,0 +1,37 @@
+package com.konkuk.strhat.core.component.picker
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.unit.Dp
+import com.konkuk.strhat.ui.theme.defaultStrHatColors
+
+@Composable
+fun GuideLines(
+    visibleItemsCount: Int,
+    itemHeightDp: Dp
+) {
+    Canvas(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(itemHeightDp * visibleItemsCount)
+    ) {
+        val borderHeight = itemHeightDp.toPx()
+        val center = size.height / 2
+        drawLine(
+            color = defaultStrHatColors.Gray400,
+            start = Offset(0f, center - borderHeight / 2),
+            end = Offset(size.width, center - borderHeight / 2),
+            strokeWidth = 0.5f
+        )
+        drawLine(
+            color = defaultStrHatColors.Gray400,
+            start = Offset(0f, center + borderHeight / 2),
+            end = Offset(size.width, center + borderHeight / 2),
+            strokeWidth = 0.5f
+        )
+    }
+}

--- a/app/src/main/java/com/konkuk/strhat/core/component/picker/PickerState.kt
+++ b/app/src/main/java/com/konkuk/strhat/core/component/picker/PickerState.kt
@@ -1,0 +1,9 @@
+package com.konkuk.strhat.core.component.picker
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+
+class PickerState {
+    var selectedItem by mutableStateOf("")
+}

--- a/app/src/main/java/com/konkuk/strhat/core/component/picker/YearPicker.kt
+++ b/app/src/main/java/com/konkuk/strhat/core/component/picker/YearPicker.kt
@@ -33,7 +33,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.mapNotNull
 
 @Composable
-fun Picker(
+fun YearPicker(
     items: List<String>,
     modifier: Modifier = Modifier,
     state: PickerState = rememberPickerState(),

--- a/app/src/main/java/com/konkuk/strhat/core/component/section/PageDescriptionSection.kt
+++ b/app/src/main/java/com/konkuk/strhat/core/component/section/PageDescriptionSection.kt
@@ -1,0 +1,70 @@
+package com.konkuk.strhat.core.component.section
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.konkuk.strhat.R
+import com.konkuk.strhat.ui.theme.StrHatTheme.colors
+import com.konkuk.strhat.ui.theme.StrHatTheme.typography
+
+@Composable
+fun PageDescriptionSection(
+    titleResId: Int,
+    modifier: Modifier = Modifier,
+    descriptionResId: Int? = null
+) {
+    Column(
+        modifier = modifier.fillMaxWidth()
+    ) {
+        Text(
+            text = stringResource(titleResId),
+            color = colors.MainBlack,
+            style = typography.head1_b_24
+        )
+
+        if (descriptionResId != null) {
+            Text(
+                text = stringResource(descriptionResId),
+                color = colors.MainBlack,
+                style = typography.body3_r_14,
+                modifier = Modifier.padding(top = 10.dp)
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewPageDescriptionSection1() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(color = colors.MainWhite)
+    ) {
+        PageDescriptionSection(
+            titleResId = R.string.onboarding_title,
+            descriptionResId = R.string.onboarding_description
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewPageDescriptionSection2() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(color = colors.MainWhite)
+    ) {
+        PageDescriptionSection(
+            titleResId = R.string.onboarding_title
+        )
+    }
+}

--- a/app/src/main/java/com/konkuk/strhat/core/component/textfield/LongTextField.kt
+++ b/app/src/main/java/com/konkuk/strhat/core/component/textfield/LongTextField.kt
@@ -1,0 +1,159 @@
+package com.konkuk.strhat.core.component.textfield
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.konkuk.strhat.R
+import com.konkuk.strhat.ui.theme.StrHatTheme.colors
+import com.konkuk.strhat.ui.theme.StrHatTheme.typography
+
+@Composable
+fun LongTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    hint: String,
+    maxLength: Int,
+    modifier: Modifier = Modifier
+) {
+    var isFocused by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp)
+    ) {
+        OutlinedTextField(
+            value = value,
+            onValueChange = {
+                if (it.length <= maxLength) onValueChange(it)
+            },
+            placeholder = {
+                Text(
+                    text = hint,
+                    style = typography.body2_r_15,
+                    color = colors.Gray400
+                )
+            },
+            modifier = modifier
+                .fillMaxWidth()
+                .height(LocalConfiguration.current.screenHeightDp.dp * 0.39f)
+                .onFocusChanged { focusState ->
+                    isFocused = focusState.isFocused
+                },
+            colors = TextFieldDefaults.colors(
+                unfocusedIndicatorColor = Color.Transparent,
+                focusedIndicatorColor = colors.MainBlack,
+                unfocusedContainerColor = colors.Gray100,
+                focusedContainerColor = colors.Gray100
+            ),
+            textStyle = typography.body1_r_16.copy(
+                color = colors.MainBlack
+            ),
+            shape = RoundedCornerShape(4.dp)
+        )
+        Text(
+            text = stringResource(R.string.textfield_long_length, value.length, maxLength),
+            color = colors.Gray400,
+            modifier = modifier.padding(top = 10.dp)
+        )
+    }
+
+}
+
+@Preview
+@Composable
+private fun PreviewLongTextFieldHobby() {
+    var text by remember { mutableStateOf("") }
+    Column(
+        modifier = Modifier
+            .background(color = colors.MainWhite)
+            .fillMaxWidth()
+            .padding(vertical = 20.dp)
+    ) {
+        LongTextField(
+            value = text,
+            onValueChange = { text = it },
+            hint = stringResource(R.string.textfield_hobby),
+            maxLength = 1000,
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewLongTextFieldStress() {
+    var text by remember { mutableStateOf("") }
+    Column(
+        modifier = Modifier
+            .background(color = colors.MainWhite)
+            .fillMaxWidth()
+            .padding(vertical = 20.dp)
+    ) {
+        LongTextField(
+            value = text,
+            onValueChange = { text = it },
+            hint = stringResource(R.string.textfield_stress_management),
+            maxLength = 1000,
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewLongTextFieldPersonality() {
+    var text by remember { mutableStateOf("") }
+    Column(
+        modifier = Modifier
+            .background(color = colors.MainWhite)
+            .fillMaxWidth()
+            .padding(vertical = 20.dp)
+    ) {
+        LongTextField(
+            value = text,
+            onValueChange = { text = it },
+            hint = stringResource(R.string.textfield_personality_type),
+            maxLength = 1000,
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewLongTextFieldDiary() {
+    var text by remember { mutableStateOf("") }
+    Column(
+        modifier = Modifier
+            .background(color = colors.MainWhite)
+            .fillMaxWidth()
+            .padding(vertical = 20.dp)
+    ) {
+        LongTextField(
+            value = text,
+            onValueChange = { text = it },
+            hint = stringResource(R.string.textfield_diary),
+            maxLength = 1500,
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}

--- a/app/src/main/java/com/konkuk/strhat/core/component/textfield/ShortTextField.kt
+++ b/app/src/main/java/com/konkuk/strhat/core/component/textfield/ShortTextField.kt
@@ -1,7 +1,6 @@
 package com.konkuk.strhat.core.component.textfield
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape

--- a/app/src/main/java/com/konkuk/strhat/core/component/textfield/ShortTextField.kt
+++ b/app/src/main/java/com/konkuk/strhat/core/component/textfield/ShortTextField.kt
@@ -1,6 +1,7 @@
 package com.konkuk.strhat.core.component.textfield
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -19,7 +20,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.konkuk.strhat.R
-import com.konkuk.strhat.ui.theme.StrHatTheme
+import com.konkuk.strhat.ui.theme.StrHatTheme.colors
+import com.konkuk.strhat.ui.theme.StrHatTheme.typography
 
 @Composable
 fun ShortTextField(
@@ -36,15 +38,11 @@ fun ShortTextField(
         placeholder = {
             Text(
                 text = hint,
-                style = StrHatTheme.typography.body1_r_16,
-                color = StrHatTheme.colors.Gray400
+                style = typography.body1_r_16,
+                color = colors.Gray400
             )
         },
         modifier = modifier
-            .background(
-                color = StrHatTheme.colors.Gray100,
-                shape = RoundedCornerShape(4.dp)
-            )
             .fillMaxWidth()
             .padding(horizontal = 20.dp)
             .onFocusChanged { focusState ->
@@ -52,11 +50,14 @@ fun ShortTextField(
             },
         colors = TextFieldDefaults.colors(
             unfocusedIndicatorColor = Color.Transparent,
-            focusedIndicatorColor = StrHatTheme.colors.MainBlack
+            focusedIndicatorColor = colors.MainBlack,
+            unfocusedContainerColor = colors.Gray100,
+            focusedContainerColor = colors.Gray100
         ),
-        textStyle = StrHatTheme.typography.body1_r_16.copy(
-            color = StrHatTheme.colors.MainBlack
-        )
+        textStyle = typography.body1_r_16.copy(
+            color = colors.MainBlack
+        ),
+        shape = RoundedCornerShape(4.dp)
     )
 
 }
@@ -65,10 +66,17 @@ fun ShortTextField(
 @Composable
 private fun PreviewShortTextField() {
     var text by remember { mutableStateOf("") }
-    ShortTextField(
-        value = text,
-        onValueChange = { text = it },
-        hint = stringResource(R.string.textfield_nickname),
-        modifier = Modifier.fillMaxWidth()
-    )
+    Column(
+        modifier = Modifier
+            .background(color = colors.MainWhite)
+            .fillMaxWidth()
+            .padding(vertical = 20.dp)
+    ) {
+        ShortTextField(
+            value = text,
+            onValueChange = { text = it },
+            hint = stringResource(R.string.textfield_nickname),
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
 }

--- a/app/src/main/java/com/konkuk/strhat/core/component/textfield/ShortTextField.kt
+++ b/app/src/main/java/com/konkuk/strhat/core/component/textfield/ShortTextField.kt
@@ -1,0 +1,75 @@
+package com.konkuk.strhat.core.component.textfield
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.konkuk.strhat.R
+import com.konkuk.strhat.ui.theme.StrHatTheme
+
+@Composable
+fun ShortTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    hint: String,
+    modifier: Modifier = Modifier
+) {
+    var isFocused by remember { mutableStateOf(false) }
+
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        placeholder = {
+            Text(
+                text = hint,
+                style = StrHatTheme.typography.body1_r_16,
+                color = StrHatTheme.colors.Gray400
+            )
+        },
+        modifier = modifier
+            .background(
+                color = StrHatTheme.colors.Gray100,
+                shape = RoundedCornerShape(4.dp)
+            )
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp)
+            .onFocusChanged { focusState ->
+                isFocused = focusState.isFocused
+            },
+        colors = TextFieldDefaults.colors(
+            unfocusedIndicatorColor = Color.Transparent,
+            focusedIndicatorColor = StrHatTheme.colors.MainBlack
+        ),
+        textStyle = StrHatTheme.typography.body1_r_16.copy(
+            color = StrHatTheme.colors.MainBlack
+        )
+    )
+
+}
+
+@Preview
+@Composable
+private fun PreviewShortTextField() {
+    var text by remember { mutableStateOf("") }
+    ShortTextField(
+        value = text,
+        onValueChange = { text = it },
+        hint = stringResource(R.string.textfield_nickname),
+        modifier = Modifier.fillMaxWidth()
+    )
+}

--- a/app/src/main/java/com/konkuk/strhat/core/util/KeyStorage.kt
+++ b/app/src/main/java/com/konkuk/strhat/core/util/KeyStorage.kt
@@ -1,0 +1,6 @@
+package com.konkuk.strhat.core.util
+
+object KeyStorage {
+    // year picker
+    const val MIN_YEAR = 2000
+}

--- a/app/src/main/java/com/konkuk/strhat/core/util/color/DropDownMenuTextColor.kt
+++ b/app/src/main/java/com/konkuk/strhat/core/util/color/DropDownMenuTextColor.kt
@@ -1,0 +1,26 @@
+package com.konkuk.strhat.core.util.color
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import com.konkuk.strhat.ui.theme.Gray500
+import com.konkuk.strhat.ui.theme.MainBlack
+import com.konkuk.strhat.ui.theme.StrHatTheme.typography
+
+@Composable
+fun setDropDownMenuTextStyle(selectedFilter: String, filter: String): DropDownMenuTextStyle {
+    val typography =
+        if (selectedFilter == filter) {
+            typography.body1_m_16
+        } else {
+            typography.body1_r_16
+        }
+
+    val color = if (selectedFilter == filter) MainBlack else Gray500
+    return DropDownMenuTextStyle(color = color, typography = typography)
+}
+
+data class DropDownMenuTextStyle(
+    val color: Color,
+    val typography: TextStyle
+)

--- a/app/src/main/java/com/konkuk/strhat/domain/type/JobType.kt
+++ b/app/src/main/java/com/konkuk/strhat/domain/type/JobType.kt
@@ -1,0 +1,15 @@
+package com.konkuk.strhat.domain.type
+
+enum class JobType (
+    val type: String
+){
+    STUDENT(
+        type = "대학생"
+    ),
+    JOBSEEKER(
+        type = "취준생"
+    ),
+    WORKER(
+        type = "직장인"
+    )
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,4 +6,7 @@
     <string name="diary">일기</string>
     <string name="self_diagnosis">자가진단</string>
     <string name="my_page">MY</string>
+
+    <!-- textfield -->
+    <string name="textfield_nickname">앱 내에서 사용될 닉네임을 입력해주세요.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,4 +26,8 @@
     <string name="textfield_diary">오늘의 일기를 1500자 이하로 작성해주세요.\n일기를 자세하고 길게 작성할 수록 스틀햇의\n정성어린 답변을 받을 수 있습니다!</string>
     <string name="textfield_long_length">%d/%d</string>
 
+    <!-- onboarding -->
+    <string name="onboarding_title">스틀햇에 오신 것을\n환영합니다!</string>
+    <string name="onboarding_description">이 정보는 AI의 맞춤형 답변에 도움됩니다.</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,5 +8,11 @@
     <string name="my_page">MY</string>
 
     <!-- textfield -->
-    <string name="textfield_nickname">앱 내에서 사용될 닉네임을 입력해주세요.</string>
+    <string name="textfield_nickname">앱 내에서 사용될 닉네임을 입력해주세요</string>
+    <string name="textfield_hobby">나만의 취미 및 힐링 방법을 1000자 이하로 작성해주세요\nex)\n1. 퍼즐 맞추는 것을 좋아함.\n2. 그림 그리는 것을 좋아함.\n3. 뜨개질하는 것을 좋아함.</string>
+    <string name="textfield_stress_management">나만의 스트레스 해소 방법을 1000자 이하로 작성해주세요\nex)\n1. 아주 매운 음식을 먹는 것을 즐김.\n2. 좋아하는 노래를 들으며 춤을 춤.\n3. 건대입구역에 있는 스타벅스에 가 사람들을 구경함.</string>
+    <string name="textfield_personality_type">나의 성향을 1000자 이하로 작성해주세요\nex)\n1. 내성적인 편임.\n2. 매사에 신중한 편임.\n3. 힘든 것을 티를 내지 않음.</string>
+    <string name="textfield_diary">오늘의 일기를 1500자 이하로 작성해주세요.\n일기를 자세하고 길게 작성할 수록 스틀햇의\n정성어린 답변을 받을 수 있습니다!</string>
+    <string name="textfield_long_length">%d/%d</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,6 +15,12 @@
     <string name="date_picker_bottom_sheet_title">날짜 선택</string>
     <string name="date_picker_visible_button">날짜 선택 버튼</string>
 
+    <!-- year picker bottom sheet -->
+    <string name="year_picker_title">태어난 년도를 선택해주세요.</string>
+    <string name="year_picker_bottom_sheet_title">태어난 년도 선택</string>
+    <string name="year_picker_bottom_sheet_button">선택</string>
+    <string name="year_picker_bottom_sheet">년</string>
+
     <!-- progress bar -->
     <string name="animated_progress_bar_label">Progress Bar Animation</string>
 
@@ -23,7 +29,7 @@
     <string name="textfield_hobby">나만의 취미 및 힐링 방법을 1000자 이하로 작성해주세요\nex)\n1. 퍼즐 맞추는 것을 좋아함.\n2. 그림 그리는 것을 좋아함.\n3. 뜨개질하는 것을 좋아함.</string>
     <string name="textfield_stress_management">나만의 스트레스 해소 방법을 1000자 이하로 작성해주세요\nex)\n1. 아주 매운 음식을 먹는 것을 즐김.\n2. 좋아하는 노래를 들으며 춤을 춤.\n3. 건대입구역에 있는 스타벅스에 가 사람들을 구경함.</string>
     <string name="textfield_personality_type">나의 성향을 1000자 이하로 작성해주세요\nex)\n1. 내성적인 편임.\n2. 매사에 신중한 편임.\n3. 힘든 것을 티를 내지 않음.</string>
-    <string name="textfield_diary">오늘의 일기를 1500자 이하로 작성해주세요.\n일기를 자세하고 길게 작성할 수록 스틀햇의\n정성어린 답변을 받을 수 있습니다!오늘의 일기를 1500자 이하로 작성해주세요.\n일기를 자세하고 길게 작성할 수록 스틀햇의\n정성어린 답변을 받을 수 있습니다!오늘의 일기를 1500자 이하로 작성해주세요.\n일기를 자세하고 길게 작성할 수록 스틀햇의\n정성어린 답변을 받을 수 있습니다!오늘의 일기를 1500자 이하로 작성해주세요.\n일기를 자세하고 길게 작성할 수록 스틀햇의\n정성어린 답변을 받을 수 있습니다!오늘의 일기를 1500자 이하로 작성해주세요.\n일기를 자세하고 길게 작성할 수록 스틀햇의\n정성어린 답변을 받을 수 있습니다!</string>
+    <string name="textfield_diary">오늘의 일기를 1500자 이하로 작성해주세요.\n일기를 자세하고 길게 작성할 수록 스틀햇의\n정성어린 답변을 받을 수 있습니다!</string>
     <string name="textfield_long_length">%d/%d</string>
 
     <!-- dialog -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,8 +23,15 @@
     <string name="textfield_hobby">나만의 취미 및 힐링 방법을 1000자 이하로 작성해주세요\nex)\n1. 퍼즐 맞추는 것을 좋아함.\n2. 그림 그리는 것을 좋아함.\n3. 뜨개질하는 것을 좋아함.</string>
     <string name="textfield_stress_management">나만의 스트레스 해소 방법을 1000자 이하로 작성해주세요\nex)\n1. 아주 매운 음식을 먹는 것을 즐김.\n2. 좋아하는 노래를 들으며 춤을 춤.\n3. 건대입구역에 있는 스타벅스에 가 사람들을 구경함.</string>
     <string name="textfield_personality_type">나의 성향을 1000자 이하로 작성해주세요\nex)\n1. 내성적인 편임.\n2. 매사에 신중한 편임.\n3. 힘든 것을 티를 내지 않음.</string>
-    <string name="textfield_diary">오늘의 일기를 1500자 이하로 작성해주세요.\n일기를 자세하고 길게 작성할 수록 스틀햇의\n정성어린 답변을 받을 수 있습니다!</string>
+    <string name="textfield_diary">오늘의 일기를 1500자 이하로 작성해주세요.\n일기를 자세하고 길게 작성할 수록 스틀햇의\n정성어린 답변을 받을 수 있습니다!오늘의 일기를 1500자 이하로 작성해주세요.\n일기를 자세하고 길게 작성할 수록 스틀햇의\n정성어린 답변을 받을 수 있습니다!오늘의 일기를 1500자 이하로 작성해주세요.\n일기를 자세하고 길게 작성할 수록 스틀햇의\n정성어린 답변을 받을 수 있습니다!오늘의 일기를 1500자 이하로 작성해주세요.\n일기를 자세하고 길게 작성할 수록 스틀햇의\n정성어린 답변을 받을 수 있습니다!오늘의 일기를 1500자 이하로 작성해주세요.\n일기를 자세하고 길게 작성할 수록 스틀햇의\n정성어린 답변을 받을 수 있습니다!</string>
     <string name="textfield_long_length">%d/%d</string>
+
+    <!-- dialog -->
+    <string name="dialog_chat_title">대화 그만하기</string>
+    <string name="dialog_chat_description">스틀햇과의 대화를 그만하시겠어요?</string>
+    <string name="dialog_logout_title">로그아웃</string>
+    <string name="dialog_logout_description">정말 로그아웃하시겠어요?</string>
+    <string name="dialog_diary_title">일기 전문보기</string>
 
     <!-- onboarding -->
     <string name="onboarding_title">스틀햇에 오신 것을\n환영합니다!</string>


### PR DESCRIPTION
## Related issue 🛠
- closed #7 

## Work Description 📝
- ShortTextField 컴포넌트 구현
- LongTextField 컴포넌트 구현
- 제목+부제목 컴포넌트 구현
- 다이얼로그 컴포넌트 구현
- 남성, 여성 선택버튼 컴포넌트 구현
- 드롭다운 컴포넌트 구현

## Screenshot 📸
<img width="644" alt="image" src="https://github.com/user-attachments/assets/62aa3acc-9f47-44dc-ac87-70e30a82f1d6" />

https://github.com/user-attachments/assets/de7a36de-9978-4c8c-a57f-7e22c34955ae

<img width="425" alt="image" src="https://github.com/user-attachments/assets/e15a2c21-d923-40ae-93a7-06d528580803" />

<img width="649" alt="image" src="https://github.com/user-attachments/assets/b8a0eba8-5a04-430b-8d0e-5e57fe70dd84" />

https://github.com/user-attachments/assets/77c0b3a1-43a8-432c-9e40-d89c53b02e7d

https://github.com/user-attachments/assets/a88bc3ac-0f7c-49f3-a480-20dc7496268e

https://github.com/user-attachments/assets/e3533f35-79a3-4af2-a3f4-b137e20db535



## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
textfield, 제목+부제목, dialog, 선택버튼, dropdown 컴포넌트 구현 완료했습니다.

각각의 사용 예시에 따라 모두 preview 만들어뒀으니 사용할 때 그대로 가져가서 쓰면 될 것 같습니다 !