### PR TITLE
[Feat/#10] 스플래시, 로그인 뷰 구현

### DIFF
--- a/app/src/main/java/com/konkuk/strhat/feature/login/LoginScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/login/LoginScreen.kt
@@ -55,7 +55,7 @@ fun LoginScreen(
     ) {
         Icon(
             imageVector = ImageVector.vectorResource(R.drawable.ic_logo_blue),
-            contentDescription = null,
+            contentDescription = stringResource(R.string.app_name_korean),
             tint = colors.MainBlue
         )
         Text(
@@ -83,7 +83,7 @@ fun LoginScreen(
         ) {
             Icon(
                 imageVector = ImageVector.vectorResource(R.drawable.ic_kakao),
-                contentDescription = null,
+                contentDescription = stringResource(R.string.app_name_korean),
                 tint = colors.MainBlack
             )
 

--- a/app/src/main/java/com/konkuk/strhat/feature/login/LoginScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/login/LoginScreen.kt
@@ -1,16 +1,31 @@
 package com.konkuk.strhat.feature.login
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.konkuk.strhat.R
+import com.konkuk.strhat.core.util.modifier.noRippleClickable
+import com.konkuk.strhat.ui.theme.StrHatTheme.colors
+import com.konkuk.strhat.ui.theme.StrHatTheme.typography
 
 @Composable
 fun LoginRoute(
@@ -32,20 +47,68 @@ fun LoginScreen(
     onButtonClick: () -> Unit,
 ) {
     Column(
-        modifier = Modifier.fillMaxSize()
+        modifier = Modifier
+            .fillMaxSize()
             .padding(padding),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center
     ) {
-        Text(
-            text = "Login Screen"
+        Icon(
+            imageVector = ImageVector.vectorResource(R.drawable.ic_logo_blue),
+            contentDescription = null,
+            tint = colors.MainBlue
         )
-        Button(
-            onClick = onButtonClick,
+        Text(
+            text = stringResource(R.string.app_name_korean),
+            color = colors.MainBlue,
+            style = typography.head1_b_24,
+            modifier = Modifier.padding(top = 20.dp)
+        )
+
+        Text(
+            text = stringResource(R.string.login_social_login),
+            color = colors.Gray500,
+            style = typography.body1_m_16,
+            modifier = Modifier.padding(top = 135.dp)
+        )
+        HorizontalDivider(color = colors.Gray500, modifier = Modifier.padding(20.dp))
+        Box(
+            modifier = Modifier
+                .padding(horizontal = 20.dp)
+                .background(color = colors.SubYellow, shape = RoundedCornerShape(8.dp))
+                .noRippleClickable(onButtonClick)
+                .fillMaxWidth()
+                .padding(20.dp),
+            contentAlignment = Alignment.CenterStart
         ) {
+            Icon(
+                imageVector = ImageVector.vectorResource(R.drawable.ic_kakao),
+                contentDescription = null,
+                tint = colors.MainBlack
+            )
+
             Text(
-                text = "Go To OnBoarding"
+                text = stringResource(R.string.login_kakao_login),
+                color = colors.MainBlack,
+                style = typography.body1_b_16,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth()
             )
         }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewLoginScreen() {
+    Column(
+        modifier = Modifier
+            .background(color = colors.MainWhite)
+            .fillMaxSize()
+    ) {
+        LoginScreen(
+            padding = PaddingValues(),
+            onButtonClick = {}
+        )
     }
 }

--- a/app/src/main/java/com/konkuk/strhat/feature/login/navigation/LoginNavigation.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/login/navigation/LoginNavigation.kt
@@ -3,12 +3,13 @@ package com.konkuk.strhat.feature.login.navigation
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.konkuk.strhat.core.navigation.Route.Login
 import com.konkuk.strhat.feature.login.LoginRoute
 
-fun NavController.navigateToLogin() {
-    navigate(Login)
+fun NavController.navigateToLogin(navOptions: NavOptions) {
+    navigate(Login, navOptions)
 }
 
 fun NavGraphBuilder.loginNavGraph(

--- a/app/src/main/java/com/konkuk/strhat/feature/main/MainNavigator.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/main/MainNavigator.kt
@@ -51,7 +51,14 @@ class MainNavigator(
     }
 
     fun navigateToLogin() {
-        navController.navigateToLogin()
+        navController.navigateToLogin(
+            navOptions {
+                popUpTo(navController.graph.findStartDestination().id) {
+                    inclusive = true
+                }
+                launchSingleTop = true
+            }
+        )
     }
 
     fun navigateToOnBoarding() {

--- a/app/src/main/java/com/konkuk/strhat/feature/splash/SplashScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/splash/SplashScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -51,7 +52,7 @@ fun SplashScreen(
     ) {
         Icon(
             imageVector = ImageVector.vectorResource(R.drawable.ic_logo_white),
-            contentDescription = null,
+            contentDescription = stringResource(R.string.app_name_korean),
             tint = colors.MainWhite
         )
     }

--- a/app/src/main/java/com/konkuk/strhat/feature/splash/SplashScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/splash/SplashScreen.kt
@@ -1,16 +1,25 @@
 package com.konkuk.strhat.feature.splash
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
-import androidx.compose.material3.Text
+import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.konkuk.strhat.R
+import com.konkuk.strhat.ui.theme.StrHatTheme
+import com.konkuk.strhat.ui.theme.StrHatTheme.colors
 
 @Composable
 fun SplashRoute(
@@ -18,34 +27,42 @@ fun SplashRoute(
     navigateToLogin: () -> Unit,
     viewModel: SplashViewModel = hiltViewModel()
 ) {
-    SplashScreen(
-        padding = padding,
-        onButtonClick = {
+    val navigateToLoginState by viewModel.navigateToLogin.collectAsState()
+
+    LaunchedEffect(navigateToLoginState) {
+        if (navigateToLoginState) {
             navigateToLogin()
         }
-    )
+    }
+    SplashScreen(padding = padding)
 }
 
 @Composable
 fun SplashScreen(
-    padding: PaddingValues,
-    onButtonClick: () -> Unit,
+    padding: PaddingValues
 ) {
     Column(
-        modifier = Modifier.fillMaxSize()
+        modifier = Modifier
+            .background(color = colors.MainBlue)
+            .fillMaxSize()
             .padding(padding),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center
     ) {
-        Text(
-            text = "Splash Screen"
+        Icon(
+            imageVector = ImageVector.vectorResource(R.drawable.ic_logo_white),
+            contentDescription = null,
+            tint = colors.MainWhite
         )
-        Button(
-            onClick = onButtonClick,
-        ) {
-            Text(
-                text = "Go To Login"
-            )
-        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewSplashScreen() {
+    StrHatTheme {
+        SplashScreen(
+            padding = PaddingValues()
+        )
     }
 }

--- a/app/src/main/java/com/konkuk/strhat/feature/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/splash/SplashViewModel.kt
@@ -16,7 +16,7 @@ class SplashViewModel @Inject constructor() : ViewModel() {
 
     init {
         viewModelScope.launch {
-            delay(3000)
+            delay(2000)
             _navigateToLogin.value = true
         }
     }

--- a/app/src/main/java/com/konkuk/strhat/feature/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/splash/SplashViewModel.kt
@@ -1,10 +1,23 @@
 package com.konkuk.strhat.feature.splash
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class SplashViewModel @Inject constructor() : ViewModel() {
+    private val _navigateToLogin = MutableStateFlow(false)
+    val navigateToLogin = _navigateToLogin.asStateFlow()
 
+    init {
+        viewModelScope.launch {
+            delay(3000)
+            _navigateToLogin.value = true
+        }
+    }
 }

--- a/app/src/main/java/com/konkuk/strhat/ui/theme/Color.kt
+++ b/app/src/main/java/com/konkuk/strhat/ui/theme/Color.kt
@@ -21,6 +21,7 @@ val MainRed = Color(0xFFFF0000)
 val SubRed = Color(0xFFFF6B6B)
 
 val MainYellow = Color(0xFFFFEE6B)
+val SubYellow = Color(0xFFFCE64A)
 
 val MainGreen = Color(0xFF85C47A)
 val SubGreen = Color(0xFFC9FCA5)
@@ -40,6 +41,7 @@ data class StrHatColors(
     val MainRed: Color,
     val SubRed: Color,
     val MainYellow: Color,
+    val SubYellow: Color,
     val MainGreen: Color,
     val SubGreen: Color,
 )
@@ -58,6 +60,7 @@ val defaultStrHatColors = StrHatColors(
     MainRed = MainRed,
     SubRed = SubRed,
     MainYellow = MainYellow,
+    SubYellow = SubYellow,
     MainGreen = MainGreen,
     SubGreen = SubGreen,
 )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <string name="app_name">StrHat</string>
+    <string name="app_name_korean">스틀햇</string>
 
     <!-- 공통 -->
     <string name="confirm">확인</string>
@@ -17,4 +18,8 @@
 
     <!-- progress bar -->
     <string name="animated_progress_bar_label">Progress Bar Animation</string>
+
+    <!-- login -->
+    <string name="login_social_login">소셜 로그인</string>
+    <string name="login_kakao_login">카카오로 계속하기</string>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.StrHat" parent="android:Theme.Material.Light.NoActionBar" />
+    <style name="Theme.StrHat" parent="android:Theme.Material.Light.NoActionBar">
+        <item name="android:windowIsTranslucent">true</item>
+    </style>
 </resources>


### PR DESCRIPTION
## Related issue 🛠
- closed #10 

## Work Description 📝
- 스플래시 뷰 구현
- 로그인 뷰 구현

## Screenshot 📸
https://github.com/user-attachments/assets/b9044612-3e16-4496-b6cc-8ae09ef53edd


## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
스플래시에서 3초 후 로그인으로 화면 자동 전환 구현했습니다. 임의로 시간을 설정한 것이기 때문에 기획상 수정이 필요하다면 시간만 수정하면 될 것 같아요!

로그인에서 뒤로 가기를 눌렀을 때, 스플래시로 가는 것이 아닌 앱이 꺼질 수 있도록 해뒀습니다. 이것도 바로 앱이 꺼지는게 아니라 토스트 메시지 등으로 앱이 꺼진다는 경고를 띄우는 등의 기획이 있다면 수정이 필요할 것 같아요.