### PR TITLE
[FEAT/#23] 일기 서버통신 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,6 +26,7 @@ android {
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "BASE_URL", properties["base.url"].toString())
+        buildConfigField("String", "TOKEN", properties["token"].toString())
     }
 
     buildTypes {

--- a/app/src/main/java/com/konkuk/strhat/core/navigation/RouteModel.kt
+++ b/app/src/main/java/com/konkuk/strhat/core/navigation/RouteModel.kt
@@ -62,7 +62,12 @@ sealed interface DiaryRoute : Route {
     @Serializable
     data object AddDiary : Route
     @Serializable
-    data object DiaryAIFeedback : Route
+    data class DiaryAIFeedback(
+        val summary: String,
+        val positiveKeywords: List<String>,
+        val negativeKeywords: List<String>,
+        val stressReliefSuggestions: String
+    ) : Route
     @Serializable
     data object Chat : Route
     @Serializable

--- a/app/src/main/java/com/konkuk/strhat/core/navigation/RouteModel.kt
+++ b/app/src/main/java/com/konkuk/strhat/core/navigation/RouteModel.kt
@@ -60,7 +60,7 @@ sealed interface MyPageRoute: Route{
 
 sealed interface DiaryRoute : Route {
     @Serializable
-    data object AddDiary : Route
+    data object AddDiary : DiaryRoute
     @Serializable
     data class DiaryAIFeedback(
         val date: String,
@@ -68,11 +68,15 @@ sealed interface DiaryRoute : Route {
         val positiveKeywords: List<String>,
         val negativeKeywords: List<String>,
         val stressReliefSuggestions: String
-    ) : Route
+    ) : DiaryRoute
     @Serializable
-    data object Chat : Route
+    data class DiaryAIFeedbackRecord(
+        val date: String
+    ) : DiaryRoute
     @Serializable
-    data object TodayStressScore : Route
+    data object Chat : DiaryRoute
+    @Serializable
+    data object TodayStressScore : DiaryRoute
 }
 
 sealed interface SelfDiagnosisRoute : Route {

--- a/app/src/main/java/com/konkuk/strhat/core/navigation/RouteModel.kt
+++ b/app/src/main/java/com/konkuk/strhat/core/navigation/RouteModel.kt
@@ -63,6 +63,7 @@ sealed interface DiaryRoute : Route {
     data object AddDiary : Route
     @Serializable
     data class DiaryAIFeedback(
+        val date: String,
         val summary: String,
         val positiveKeywords: List<String>,
         val negativeKeywords: List<String>,

--- a/app/src/main/java/com/konkuk/strhat/core/network/TokenManager.kt
+++ b/app/src/main/java/com/konkuk/strhat/core/network/TokenManager.kt
@@ -1,0 +1,19 @@
+package com.konkuk.strhat.core.network
+
+import android.content.SharedPreferences
+import com.konkuk.strhat.BuildConfig.TOKEN
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class TokenManager @Inject constructor(
+    private val sharedPreferences: SharedPreferences
+) {
+    fun getToken(): String {
+        return sharedPreferences.getString(TOKEN, "").orEmpty()
+    }
+
+    fun saveToken(token: String) {
+        sharedPreferences.edit().putString(TOKEN, token).apply()
+    }
+}

--- a/app/src/main/java/com/konkuk/strhat/data/datasource/DiaryDataSource.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/datasource/DiaryDataSource.kt
@@ -10,4 +10,5 @@ interface DiaryDataSource {
     suspend fun postDiary(request: RequestAddDiaryDto): BaseResponse<ResponseSaveDiaryDto>
     suspend fun getTotalDiary(date: String): BaseResponse<ResponseTotalDiaryDto>
     suspend fun getDiaryExistence(date: String): BaseResponse<ResponseDiaryExistenceDto>
+    suspend fun getDiaryFeedback(date: String): BaseResponse<ResponseSaveDiaryDto>
 }

--- a/app/src/main/java/com/konkuk/strhat/data/datasource/DiaryDataSource.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/datasource/DiaryDataSource.kt
@@ -3,7 +3,9 @@ package com.konkuk.strhat.data.datasource
 import com.konkuk.strhat.data.dto.base.BaseResponse
 import com.konkuk.strhat.data.dto.request.RequestAddDiaryDto
 import com.konkuk.strhat.data.dto.response.ResponseSaveDiaryDto
+import com.konkuk.strhat.data.dto.response.ResponseTotalDiaryDto
 
 interface DiaryDataSource {
     suspend fun postDiary(request: RequestAddDiaryDto): BaseResponse<ResponseSaveDiaryDto>
+    suspend fun getTotalDiary(date: String): BaseResponse<ResponseTotalDiaryDto>
 }

--- a/app/src/main/java/com/konkuk/strhat/data/datasource/DiaryDataSource.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/datasource/DiaryDataSource.kt
@@ -2,10 +2,12 @@ package com.konkuk.strhat.data.datasource
 
 import com.konkuk.strhat.data.dto.base.BaseResponse
 import com.konkuk.strhat.data.dto.request.RequestAddDiaryDto
+import com.konkuk.strhat.data.dto.response.ResponseDiaryExistenceDto
 import com.konkuk.strhat.data.dto.response.ResponseSaveDiaryDto
 import com.konkuk.strhat.data.dto.response.ResponseTotalDiaryDto
 
 interface DiaryDataSource {
     suspend fun postDiary(request: RequestAddDiaryDto): BaseResponse<ResponseSaveDiaryDto>
     suspend fun getTotalDiary(date: String): BaseResponse<ResponseTotalDiaryDto>
+    suspend fun getDiaryExistence(date: String): BaseResponse<ResponseDiaryExistenceDto>
 }

--- a/app/src/main/java/com/konkuk/strhat/data/datasource/DiaryDataSource.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/datasource/DiaryDataSource.kt
@@ -1,0 +1,9 @@
+package com.konkuk.strhat.data.datasource
+
+import com.konkuk.strhat.data.dto.base.BaseResponse
+import com.konkuk.strhat.data.dto.request.RequestAddDiaryDto
+import com.konkuk.strhat.data.dto.response.ResponseSaveDiaryDto
+
+interface DiaryDataSource {
+    suspend fun postDiary(request: RequestAddDiaryDto): BaseResponse<ResponseSaveDiaryDto>
+}

--- a/app/src/main/java/com/konkuk/strhat/data/datasourceimpl/DiaryDataSourceImpl.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/datasourceimpl/DiaryDataSourceImpl.kt
@@ -4,6 +4,7 @@ import com.konkuk.strhat.data.datasource.DiaryDataSource
 import com.konkuk.strhat.data.dto.base.BaseResponse
 import com.konkuk.strhat.data.dto.request.RequestAddDiaryDto
 import com.konkuk.strhat.data.dto.response.ResponseSaveDiaryDto
+import com.konkuk.strhat.data.dto.response.ResponseTotalDiaryDto
 import com.konkuk.strhat.data.service.DiaryService
 import javax.inject.Inject
 
@@ -12,4 +13,7 @@ class DiaryDataSourceImpl @Inject constructor(
 ) : DiaryDataSource {
     override suspend fun postDiary(request: RequestAddDiaryDto): BaseResponse<ResponseSaveDiaryDto> =
         diaryService.sendDiary(request)
+
+    override suspend fun getTotalDiary(date: String): BaseResponse<ResponseTotalDiaryDto> =
+        diaryService.getTotalDiary(date = date)
 }

--- a/app/src/main/java/com/konkuk/strhat/data/datasourceimpl/DiaryDataSourceImpl.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/datasourceimpl/DiaryDataSourceImpl.kt
@@ -3,6 +3,7 @@ package com.konkuk.strhat.data.datasourceimpl
 import com.konkuk.strhat.data.datasource.DiaryDataSource
 import com.konkuk.strhat.data.dto.base.BaseResponse
 import com.konkuk.strhat.data.dto.request.RequestAddDiaryDto
+import com.konkuk.strhat.data.dto.response.ResponseDiaryExistenceDto
 import com.konkuk.strhat.data.dto.response.ResponseSaveDiaryDto
 import com.konkuk.strhat.data.dto.response.ResponseTotalDiaryDto
 import com.konkuk.strhat.data.service.DiaryService
@@ -15,5 +16,8 @@ class DiaryDataSourceImpl @Inject constructor(
         diaryService.sendDiary(request)
 
     override suspend fun getTotalDiary(date: String): BaseResponse<ResponseTotalDiaryDto> =
-        diaryService.getTotalDiary(date = date)
+        diaryService.getTotalDiary(date)
+
+    override suspend fun getDiaryExistence(date: String): BaseResponse<ResponseDiaryExistenceDto> =
+        diaryService.getDiaryExistence(date)
 }

--- a/app/src/main/java/com/konkuk/strhat/data/datasourceimpl/DiaryDataSourceImpl.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/datasourceimpl/DiaryDataSourceImpl.kt
@@ -20,4 +20,7 @@ class DiaryDataSourceImpl @Inject constructor(
 
     override suspend fun getDiaryExistence(date: String): BaseResponse<ResponseDiaryExistenceDto> =
         diaryService.getDiaryExistence(date)
+
+    override suspend fun getDiaryFeedback(date: String): BaseResponse<ResponseSaveDiaryDto> =
+        diaryService.getDiaryFeedback(date)
 }

--- a/app/src/main/java/com/konkuk/strhat/data/datasourceimpl/DiaryDataSourceImpl.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/datasourceimpl/DiaryDataSourceImpl.kt
@@ -1,0 +1,15 @@
+package com.konkuk.strhat.data.datasourceimpl
+
+import com.konkuk.strhat.data.datasource.DiaryDataSource
+import com.konkuk.strhat.data.dto.base.BaseResponse
+import com.konkuk.strhat.data.dto.request.RequestAddDiaryDto
+import com.konkuk.strhat.data.dto.response.ResponseSaveDiaryDto
+import com.konkuk.strhat.data.service.DiaryService
+import javax.inject.Inject
+
+class DiaryDataSourceImpl @Inject constructor(
+    private val diaryService: DiaryService
+) : DiaryDataSource {
+    override suspend fun postDiary(request: RequestAddDiaryDto): BaseResponse<ResponseSaveDiaryDto> =
+        diaryService.sendDiary(request)
+}

--- a/app/src/main/java/com/konkuk/strhat/data/di/ApiModule.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/di/ApiModule.kt
@@ -1,5 +1,6 @@
 package com.konkuk.strhat.data.di
 
+import com.konkuk.strhat.data.service.DiaryService
 import com.konkuk.strhat.data.service.HomeService
 import dagger.Module
 import dagger.Provides
@@ -15,4 +16,9 @@ object ApiModule {
     @Singleton
     fun providesHomeService(retrofit: Retrofit): HomeService =
         retrofit.create(HomeService::class.java)
+
+    @Provides
+    @Singleton
+    fun providesDiaryService(retrofit: Retrofit): DiaryService =
+        retrofit.create(DiaryService::class.java)
 }

--- a/app/src/main/java/com/konkuk/strhat/data/di/DataSourceModule.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/di/DataSourceModule.kt
@@ -1,6 +1,8 @@
 package com.konkuk.strhat.data.di
 
+import com.konkuk.strhat.data.datasource.DiaryDataSource
 import com.konkuk.strhat.data.datasource.HomeDataSource
+import com.konkuk.strhat.data.datasourceimpl.DiaryDataSourceImpl
 import com.konkuk.strhat.data.datasourceimpl.HomeDataSourceImpl
 import dagger.Binds
 import dagger.Module
@@ -14,4 +16,8 @@ abstract class DataSourceModule {
     @Binds
     @Singleton
     abstract fun bindsHomeDataSource(homeDataSourceImpl: HomeDataSourceImpl): HomeDataSource
+
+    @Binds
+    @Singleton
+    abstract fun bindsDiaryDataSource(diaryDataSourceImpl: DiaryDataSourceImpl): DiaryDataSource
 }

--- a/app/src/main/java/com/konkuk/strhat/data/di/NetworkModule.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/di/NetworkModule.kt
@@ -2,6 +2,7 @@ package com.konkuk.strhat.data.di
 
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import com.konkuk.strhat.BuildConfig
+import com.konkuk.strhat.core.network.TokenManager
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -21,6 +22,24 @@ object NetworkModule {
     @Singleton
     fun providesLoggingInterceptor() = HttpLoggingInterceptor().apply {
         level = HttpLoggingInterceptor.Level.BODY
+    }
+
+    @Provides
+    @Singleton
+    fun providesAuthorizationInterceptor(
+        tokenManager: TokenManager
+    ): okhttp3.Interceptor = okhttp3.Interceptor { chain ->
+        // val token = tokenManager.getToken()
+        val token = if (BuildConfig.TOKEN.isNotBlank()) {
+            BuildConfig.TOKEN
+        } else {
+            tokenManager.getToken()
+        }
+
+        val request = chain.request().newBuilder()
+            .addHeader("Authorization", "Bearer $token")
+            .build()
+        chain.proceed(request)
     }
 
     @Provides

--- a/app/src/main/java/com/konkuk/strhat/data/di/RepositoryModule.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/di/RepositoryModule.kt
@@ -1,6 +1,8 @@
 package com.konkuk.strhat.data.di
 
+import com.konkuk.strhat.data.repositoryimpl.DiaryRepositoryImpl
 import com.konkuk.strhat.data.repositoryimpl.HomeRepositoryImpl
+import com.konkuk.strhat.domain.repository.DiaryRepository
 import com.konkuk.strhat.domain.repository.HomeRepository
 import dagger.Binds
 import dagger.Module
@@ -14,4 +16,8 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindsHomeRepository(homeRepositoryImpl: HomeRepositoryImpl): HomeRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindsDiaryRepository(diaryRepositoryImpl: DiaryRepositoryImpl): DiaryRepository
 }

--- a/app/src/main/java/com/konkuk/strhat/data/di/SharedPreferencesModule.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/di/SharedPreferencesModule.kt
@@ -1,0 +1,20 @@
+package com.konkuk.strhat.data.di
+
+import android.content.Context
+import android.content.SharedPreferences
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object SharedPreferencesModule {
+    @Provides
+    @Singleton
+    fun providesSharedPreferences(@ApplicationContext context: Context): SharedPreferences {
+        return context.getSharedPreferences("prefs", Context.MODE_PRIVATE)
+    }
+}

--- a/app/src/main/java/com/konkuk/strhat/data/dto/base/BaseErrorResponse.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/dto/base/BaseErrorResponse.kt
@@ -4,9 +4,13 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class BaseResponse<T>(
+data class BaseErrorResponse(
     @SerialName("isSuccess")
     val isSuccess: Boolean,
-    @SerialName("response")
-    val response: T
+    @SerialName("status")
+    val status: Int,
+    @SerialName("code")
+    val code: String,
+    @SerialName("message")
+    val message: String,
 )

--- a/app/src/main/java/com/konkuk/strhat/data/dto/request/RequestAddDiaryDto.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/dto/request/RequestAddDiaryDto.kt
@@ -1,0 +1,14 @@
+package com.konkuk.strhat.data.dto.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RequestAddDiaryDto(
+    @SerialName("date")
+    val date: String,
+    @SerialName("emotion")
+    val emotion: Int,
+    @SerialName("content")
+    val content: String
+)

--- a/app/src/main/java/com/konkuk/strhat/data/dto/response/ResponseDiaryExistenceDto.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/dto/response/ResponseDiaryExistenceDto.kt
@@ -1,0 +1,14 @@
+package com.konkuk.strhat.data.dto.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ResponseDiaryExistenceDto(
+    @SerialName("hasDiary")
+    val hasDiary: Boolean,
+    @SerialName("emotion")
+    val emotion: Int?,
+    @SerialName("summary")
+    val summary: String?
+)

--- a/app/src/main/java/com/konkuk/strhat/data/dto/response/ResponseSaveDiaryDto.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/dto/response/ResponseSaveDiaryDto.kt
@@ -1,0 +1,16 @@
+package com.konkuk.strhat.data.dto.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ResponseSaveDiaryDto(
+    @SerialName("summary")
+    val summary: String,
+    @SerialName("positiveKeywords")
+    val positiveKeywords: List<String>,
+    @SerialName("negativeKeywords")
+    val negativeKeywords: List<String>,
+    @SerialName("stressReliefSuggestions")
+    val stressReliefSuggestions: String
+)

--- a/app/src/main/java/com/konkuk/strhat/data/dto/response/ResponseTotalDiaryDto.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/dto/response/ResponseTotalDiaryDto.kt
@@ -1,0 +1,10 @@
+package com.konkuk.strhat.data.dto.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ResponseTotalDiaryDto(
+    @SerialName("content")
+    val content: String
+)

--- a/app/src/main/java/com/konkuk/strhat/data/mapper/DiaryMapper.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/mapper/DiaryMapper.kt
@@ -1,7 +1,9 @@
 package com.konkuk.strhat.data.mapper
 
+import com.konkuk.strhat.data.dto.response.ResponseDiaryExistenceDto
 import com.konkuk.strhat.data.dto.response.ResponseSaveDiaryDto
 import com.konkuk.strhat.data.dto.response.ResponseTotalDiaryDto
+import com.konkuk.strhat.domain.entity.DiaryExistenceModel
 import com.konkuk.strhat.domain.entity.DiaryFeedbackModel
 import com.konkuk.strhat.domain.entity.TotalDiaryModel
 
@@ -14,4 +16,10 @@ fun ResponseSaveDiaryDto.toDiaryFeedbackModel() = DiaryFeedbackModel(
 
 fun ResponseTotalDiaryDto.toTotalDiaryModel() = TotalDiaryModel(
     content = content
+)
+
+fun ResponseDiaryExistenceDto.toDiaryExistenceModel() = DiaryExistenceModel(
+    hasDiary = hasDiary,
+    emotion = emotion,
+    summary = summary
 )

--- a/app/src/main/java/com/konkuk/strhat/data/mapper/DiaryMapper.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/mapper/DiaryMapper.kt
@@ -1,0 +1,11 @@
+package com.konkuk.strhat.data.mapper
+
+import com.konkuk.strhat.data.dto.response.ResponseSaveDiaryDto
+import com.konkuk.strhat.domain.entity.DiaryFeedbackModel
+
+fun ResponseSaveDiaryDto.toDiaryFeedbackModel() = DiaryFeedbackModel(
+    summary = summary,
+    positiveKeywords = positiveKeywords,
+    negativeKeywords = negativeKeywords,
+    stressReliefSuggestions = stressReliefSuggestions
+)

--- a/app/src/main/java/com/konkuk/strhat/data/mapper/DiaryMapper.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/mapper/DiaryMapper.kt
@@ -1,11 +1,17 @@
 package com.konkuk.strhat.data.mapper
 
 import com.konkuk.strhat.data.dto.response.ResponseSaveDiaryDto
+import com.konkuk.strhat.data.dto.response.ResponseTotalDiaryDto
 import com.konkuk.strhat.domain.entity.DiaryFeedbackModel
+import com.konkuk.strhat.domain.entity.TotalDiaryModel
 
 fun ResponseSaveDiaryDto.toDiaryFeedbackModel() = DiaryFeedbackModel(
     summary = summary,
     positiveKeywords = positiveKeywords,
     negativeKeywords = negativeKeywords,
     stressReliefSuggestions = stressReliefSuggestions
+)
+
+fun ResponseTotalDiaryDto.toTotalDiaryModel() = TotalDiaryModel(
+    content = content
 )

--- a/app/src/main/java/com/konkuk/strhat/data/repositoryimpl/DiaryRepositoryImpl.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/repositoryimpl/DiaryRepositoryImpl.kt
@@ -31,4 +31,10 @@ class DiaryRepositoryImpl @Inject constructor(
             val response = diaryDataSource.getDiaryExistence(date)
             response.response.toDiaryExistenceModel()
         }
+
+    override suspend fun getDiaryFeedback(date: String): Result<DiaryFeedbackModel> =
+        runCatching {
+            val response = diaryDataSource.getDiaryFeedback(date)
+            response.response.toDiaryFeedbackModel()
+        }
 }

--- a/app/src/main/java/com/konkuk/strhat/data/repositoryimpl/DiaryRepositoryImpl.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/repositoryimpl/DiaryRepositoryImpl.kt
@@ -1,0 +1,18 @@
+package com.konkuk.strhat.data.repositoryimpl
+
+import com.konkuk.strhat.data.datasource.DiaryDataSource
+import com.konkuk.strhat.data.dto.request.RequestAddDiaryDto
+import com.konkuk.strhat.data.mapper.toDiaryFeedbackModel
+import com.konkuk.strhat.domain.entity.DiaryFeedbackModel
+import com.konkuk.strhat.domain.repository.DiaryRepository
+import javax.inject.Inject
+
+class DiaryRepositoryImpl @Inject constructor(
+    private val diaryDataSource: DiaryDataSource
+) : DiaryRepository {
+    override suspend fun postDiary(request: RequestAddDiaryDto): Result<DiaryFeedbackModel> =
+        runCatching {
+            val response = diaryDataSource.postDiary(request)
+            response.response.toDiaryFeedbackModel()
+        }
+}

--- a/app/src/main/java/com/konkuk/strhat/data/repositoryimpl/DiaryRepositoryImpl.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/repositoryimpl/DiaryRepositoryImpl.kt
@@ -3,7 +3,9 @@ package com.konkuk.strhat.data.repositoryimpl
 import com.konkuk.strhat.data.datasource.DiaryDataSource
 import com.konkuk.strhat.data.dto.request.RequestAddDiaryDto
 import com.konkuk.strhat.data.mapper.toDiaryFeedbackModel
+import com.konkuk.strhat.data.mapper.toTotalDiaryModel
 import com.konkuk.strhat.domain.entity.DiaryFeedbackModel
+import com.konkuk.strhat.domain.entity.TotalDiaryModel
 import com.konkuk.strhat.domain.repository.DiaryRepository
 import javax.inject.Inject
 
@@ -14,5 +16,11 @@ class DiaryRepositoryImpl @Inject constructor(
         runCatching {
             val response = diaryDataSource.postDiary(request)
             response.response.toDiaryFeedbackModel()
+        }
+
+    override suspend fun getTotalDiary(date: String): Result<TotalDiaryModel> =
+        runCatching {
+            val response = diaryDataSource.getTotalDiary(date)
+            response.response.toTotalDiaryModel()
         }
 }

--- a/app/src/main/java/com/konkuk/strhat/data/repositoryimpl/DiaryRepositoryImpl.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/repositoryimpl/DiaryRepositoryImpl.kt
@@ -2,8 +2,10 @@ package com.konkuk.strhat.data.repositoryimpl
 
 import com.konkuk.strhat.data.datasource.DiaryDataSource
 import com.konkuk.strhat.data.dto.request.RequestAddDiaryDto
+import com.konkuk.strhat.data.mapper.toDiaryExistenceModel
 import com.konkuk.strhat.data.mapper.toDiaryFeedbackModel
 import com.konkuk.strhat.data.mapper.toTotalDiaryModel
+import com.konkuk.strhat.domain.entity.DiaryExistenceModel
 import com.konkuk.strhat.domain.entity.DiaryFeedbackModel
 import com.konkuk.strhat.domain.entity.TotalDiaryModel
 import com.konkuk.strhat.domain.repository.DiaryRepository
@@ -22,5 +24,11 @@ class DiaryRepositoryImpl @Inject constructor(
         runCatching {
             val response = diaryDataSource.getTotalDiary(date)
             response.response.toTotalDiaryModel()
+        }
+
+    override suspend fun getDiaryExistence(date: String): Result<DiaryExistenceModel> =
+        runCatching {
+            val response = diaryDataSource.getDiaryExistence(date)
+            response.response.toDiaryExistenceModel()
         }
 }

--- a/app/src/main/java/com/konkuk/strhat/data/repositoryimpl/HomeRepositoryImpl.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/repositoryimpl/HomeRepositoryImpl.kt
@@ -12,6 +12,6 @@ class HomeRepositoryImpl @Inject constructor(
     override suspend fun getHomeData(): Result<HomeModel> =
         runCatching {
             val response = homeDataSource.getHomeData()
-            response.result?.toHomeModel() ?: throw Exception("Response data is null")
+            response.response.toHomeModel() ?: throw Exception("Response data is null")
         }
 }

--- a/app/src/main/java/com/konkuk/strhat/data/service/DiaryService.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/service/DiaryService.kt
@@ -2,6 +2,7 @@ package com.konkuk.strhat.data.service
 
 import com.konkuk.strhat.data.dto.base.BaseResponse
 import com.konkuk.strhat.data.dto.request.RequestAddDiaryDto
+import com.konkuk.strhat.data.dto.response.ResponseDiaryExistenceDto
 import com.konkuk.strhat.data.dto.response.ResponseSaveDiaryDto
 import com.konkuk.strhat.data.dto.response.ResponseTotalDiaryDto
 import retrofit2.http.Body
@@ -19,4 +20,9 @@ interface DiaryService {
     suspend fun getTotalDiary(
         @Query("date") date: String
     ): BaseResponse<ResponseTotalDiaryDto>
+
+    @GET("/api/v1/diary/exists")
+    suspend fun getDiaryExistence(
+        @Query("date") date: String
+    ): BaseResponse<ResponseDiaryExistenceDto>
 }

--- a/app/src/main/java/com/konkuk/strhat/data/service/DiaryService.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/service/DiaryService.kt
@@ -3,12 +3,20 @@ package com.konkuk.strhat.data.service
 import com.konkuk.strhat.data.dto.base.BaseResponse
 import com.konkuk.strhat.data.dto.request.RequestAddDiaryDto
 import com.konkuk.strhat.data.dto.response.ResponseSaveDiaryDto
+import com.konkuk.strhat.data.dto.response.ResponseTotalDiaryDto
 import retrofit2.http.Body
+import retrofit2.http.GET
 import retrofit2.http.POST
+import retrofit2.http.Query
 
 interface DiaryService {
     @POST("/api/v1/diary")
     suspend fun sendDiary(
         @Body request: RequestAddDiaryDto
     ): BaseResponse<ResponseSaveDiaryDto>
+
+    @GET("/api/v1/diary")
+    suspend fun getTotalDiary(
+        @Query("date") date: String
+    ): BaseResponse<ResponseTotalDiaryDto>
 }

--- a/app/src/main/java/com/konkuk/strhat/data/service/DiaryService.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/service/DiaryService.kt
@@ -25,4 +25,9 @@ interface DiaryService {
     suspend fun getDiaryExistence(
         @Query("date") date: String
     ): BaseResponse<ResponseDiaryExistenceDto>
+
+    @GET("/api/v1/diary/feedback")
+    suspend fun getDiaryFeedback(
+        @Query("date") date: String
+    ): BaseResponse<ResponseSaveDiaryDto>
 }

--- a/app/src/main/java/com/konkuk/strhat/data/service/DiaryService.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/service/DiaryService.kt
@@ -1,0 +1,14 @@
+package com.konkuk.strhat.data.service
+
+import com.konkuk.strhat.data.dto.base.BaseResponse
+import com.konkuk.strhat.data.dto.request.RequestAddDiaryDto
+import com.konkuk.strhat.data.dto.response.ResponseSaveDiaryDto
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface DiaryService {
+    @POST("/api/v1/diary")
+    suspend fun sendDiary(
+        @Body request: RequestAddDiaryDto
+    ): BaseResponse<ResponseSaveDiaryDto>
+}

--- a/app/src/main/java/com/konkuk/strhat/domain/entity/DiaryExistenceModel.kt
+++ b/app/src/main/java/com/konkuk/strhat/domain/entity/DiaryExistenceModel.kt
@@ -1,0 +1,10 @@
+package com.konkuk.strhat.domain.entity
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DiaryExistenceModel(
+    val hasDiary: Boolean,
+    val emotion: Int?,
+    val summary: String?
+)

--- a/app/src/main/java/com/konkuk/strhat/domain/entity/DiaryFeedbackModel.kt
+++ b/app/src/main/java/com/konkuk/strhat/domain/entity/DiaryFeedbackModel.kt
@@ -1,0 +1,11 @@
+package com.konkuk.strhat.domain.entity
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DiaryFeedbackModel(
+    val summary: String,
+    val positiveKeywords: List<String>,
+    val negativeKeywords: List<String>,
+    val stressReliefSuggestions: String
+)

--- a/app/src/main/java/com/konkuk/strhat/domain/entity/TotalDiaryModel.kt
+++ b/app/src/main/java/com/konkuk/strhat/domain/entity/TotalDiaryModel.kt
@@ -1,0 +1,8 @@
+package com.konkuk.strhat.domain.entity
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TotalDiaryModel(
+    val content: String
+)

--- a/app/src/main/java/com/konkuk/strhat/domain/repository/DiaryRepository.kt
+++ b/app/src/main/java/com/konkuk/strhat/domain/repository/DiaryRepository.kt
@@ -9,4 +9,5 @@ interface DiaryRepository {
     suspend fun postDiary(request: RequestAddDiaryDto): Result<DiaryFeedbackModel>
     suspend fun getTotalDiary(date: String): Result<TotalDiaryModel>
     suspend fun getDiaryExistence(date: String): Result<DiaryExistenceModel>
+    suspend fun getDiaryFeedback(date: String): Result<DiaryFeedbackModel>
 }

--- a/app/src/main/java/com/konkuk/strhat/domain/repository/DiaryRepository.kt
+++ b/app/src/main/java/com/konkuk/strhat/domain/repository/DiaryRepository.kt
@@ -1,10 +1,12 @@
 package com.konkuk.strhat.domain.repository
 
 import com.konkuk.strhat.data.dto.request.RequestAddDiaryDto
+import com.konkuk.strhat.domain.entity.DiaryExistenceModel
 import com.konkuk.strhat.domain.entity.DiaryFeedbackModel
 import com.konkuk.strhat.domain.entity.TotalDiaryModel
 
 interface DiaryRepository {
     suspend fun postDiary(request: RequestAddDiaryDto): Result<DiaryFeedbackModel>
     suspend fun getTotalDiary(date: String): Result<TotalDiaryModel>
+    suspend fun getDiaryExistence(date: String): Result<DiaryExistenceModel>
 }

--- a/app/src/main/java/com/konkuk/strhat/domain/repository/DiaryRepository.kt
+++ b/app/src/main/java/com/konkuk/strhat/domain/repository/DiaryRepository.kt
@@ -2,7 +2,9 @@ package com.konkuk.strhat.domain.repository
 
 import com.konkuk.strhat.data.dto.request.RequestAddDiaryDto
 import com.konkuk.strhat.domain.entity.DiaryFeedbackModel
+import com.konkuk.strhat.domain.entity.TotalDiaryModel
 
 interface DiaryRepository {
     suspend fun postDiary(request: RequestAddDiaryDto): Result<DiaryFeedbackModel>
+    suspend fun getTotalDiary(date: String): Result<TotalDiaryModel>
 }

--- a/app/src/main/java/com/konkuk/strhat/domain/repository/DiaryRepository.kt
+++ b/app/src/main/java/com/konkuk/strhat/domain/repository/DiaryRepository.kt
@@ -1,0 +1,8 @@
+package com.konkuk.strhat.domain.repository
+
+import com.konkuk.strhat.data.dto.request.RequestAddDiaryDto
+import com.konkuk.strhat.domain.entity.DiaryFeedbackModel
+
+interface DiaryRepository {
+    suspend fun postDiary(request: RequestAddDiaryDto): Result<DiaryFeedbackModel>
+}

--- a/app/src/main/java/com/konkuk/strhat/feature/diary/AddDiaryScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/diary/AddDiaryScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -28,19 +29,28 @@ import com.konkuk.strhat.R
 import com.konkuk.strhat.core.component.button.StrHatButton
 import com.konkuk.strhat.core.component.section.PageDescriptionSection
 import com.konkuk.strhat.core.component.textfield.LongTextField
+import com.konkuk.strhat.data.dto.request.RequestAddDiaryDto
+import com.konkuk.strhat.domain.entity.DiaryFeedbackModel
 import com.konkuk.strhat.feature.diary.component.EmotionSelection
 import com.konkuk.strhat.ui.theme.StrHatTheme
 import com.konkuk.strhat.ui.theme.StrHatTheme.colors
 import com.konkuk.strhat.ui.theme.StrHatTheme.typography
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 @Composable
 fun AddDiaryRoute(
     padding: PaddingValues,
-    navigateToDiaryAIFeedback: () -> Unit
+    navigateToDiaryAIFeedback: (DiaryFeedbackModel) -> Unit,
+    viewModel: AddDiaryViewModel = hiltViewModel()
 ) {
     AddDiaryScreen(
         padding = padding,
-        onGetFeedbackBtnClick = navigateToDiaryAIFeedback
+        onGetFeedbackBtnClick = {
+            navigateToDiaryAIFeedback(viewModel.diaryFeedbackState.value)
+        }
     )
 }
 
@@ -53,6 +63,8 @@ fun AddDiaryScreen(
 ) {
     var diaryContent by remember { mutableStateOf("") }
     var selectedEmotionIndex by remember { mutableStateOf(-1) }
+
+    val coroutineScope = rememberCoroutineScope()
 
     Column(
         modifier = modifier
@@ -127,10 +139,25 @@ fun AddDiaryScreen(
         }
 
         StrHatButton(
-            isDisabled = diaryContent.length < 20,
+            isDisabled = diaryContent.length < 20 || selectedEmotionIndex == -1,
             text = stringResource(R.string.get_feedback_button),
             modifier = Modifier.padding(20.dp),
-            onClick = onGetFeedbackBtnClick
+            onClick = {
+                val date = LocalDate.now().format(DateTimeFormatter.ISO_DATE)
+                val emotionScore = viewModel.emotionTypes[selectedEmotionIndex].score
+
+                viewModel.postDiary(
+                    request = RequestAddDiaryDto(
+                        date = date,
+                        emotion = emotionScore,
+                        content = diaryContent
+                    )
+                )
+                coroutineScope.launch {
+                    delay(4000) // 테스트 해보니 피드백 생성 주로 3초대 소요
+                    onGetFeedbackBtnClick()
+                }
+            }
         )
     }
 }

--- a/app/src/main/java/com/konkuk/strhat/feature/diary/AddDiaryScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/diary/AddDiaryScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -46,10 +47,30 @@ fun AddDiaryRoute(
     navigateToDiaryAIFeedback: (String, DiaryFeedbackModel) -> Unit,
     viewModel: AddDiaryViewModel = hiltViewModel()
 ) {
+    val coroutineScope = rememberCoroutineScope()
+
     AddDiaryScreen(
         padding = padding,
         onGetFeedbackBtnClick = { date ->
-            navigateToDiaryAIFeedback(date, viewModel.diaryFeedbackState.value)
+            val diaryContent = viewModel.diaryContentState.value
+            val selectedEmotionIndex = viewModel.selectedEmotionIndexState.value
+
+            if (selectedEmotionIndex != -1 && diaryContent.length >= 20) {
+                val emotionScore = viewModel.emotionTypes[selectedEmotionIndex].score
+
+                viewModel.postDiary(
+                    request = RequestAddDiaryDto(
+                        date = date,
+                        emotion = emotionScore,
+                        content = diaryContent
+                    )
+                )
+
+                coroutineScope.launch {
+                    delay(5000)
+                    navigateToDiaryAIFeedback(date, viewModel.diaryFeedbackState.value)
+                }
+            }
         }
     )
 }
@@ -64,7 +85,13 @@ fun AddDiaryScreen(
     var diaryContent by remember { mutableStateOf("") }
     var selectedEmotionIndex by remember { mutableStateOf(-1) }
 
-    val coroutineScope = rememberCoroutineScope()
+    LaunchedEffect(diaryContent) {
+        viewModel.diaryContentState.value = diaryContent
+    }
+
+    LaunchedEffect(selectedEmotionIndex) {
+        viewModel.selectedEmotionIndexState.value = selectedEmotionIndex
+    }
 
     Column(
         modifier = modifier
@@ -144,19 +171,7 @@ fun AddDiaryScreen(
             modifier = Modifier.padding(20.dp),
             onClick = {
                 val date = LocalDate.now().format(DateTimeFormatter.ISO_DATE)
-                val emotionScore = viewModel.emotionTypes[selectedEmotionIndex].score
-
-                viewModel.postDiary(
-                    request = RequestAddDiaryDto(
-                        date = date,
-                        emotion = emotionScore,
-                        content = diaryContent
-                    )
-                )
-                coroutineScope.launch {
-                    delay(5000) // 테스트 해보니 피드백 생성 주로 3초대 소요
-                    onGetFeedbackBtnClick(date)
-                }
+                onGetFeedbackBtnClick(date)
             }
         )
     }

--- a/app/src/main/java/com/konkuk/strhat/feature/diary/AddDiaryScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/diary/AddDiaryScreen.kt
@@ -43,13 +43,13 @@ import java.time.format.DateTimeFormatter
 @Composable
 fun AddDiaryRoute(
     padding: PaddingValues,
-    navigateToDiaryAIFeedback: (DiaryFeedbackModel) -> Unit,
+    navigateToDiaryAIFeedback: (String, DiaryFeedbackModel) -> Unit,
     viewModel: AddDiaryViewModel = hiltViewModel()
 ) {
     AddDiaryScreen(
         padding = padding,
-        onGetFeedbackBtnClick = {
-            navigateToDiaryAIFeedback(viewModel.diaryFeedbackState.value)
+        onGetFeedbackBtnClick = { date ->
+            navigateToDiaryAIFeedback(date, viewModel.diaryFeedbackState.value)
         }
     )
 }
@@ -57,7 +57,7 @@ fun AddDiaryRoute(
 @Composable
 fun AddDiaryScreen(
     padding: PaddingValues,
-    onGetFeedbackBtnClick: () -> Unit,
+    onGetFeedbackBtnClick: (String) -> Unit,
     viewModel: AddDiaryViewModel = hiltViewModel(),
     modifier: Modifier = Modifier
 ) {
@@ -154,8 +154,8 @@ fun AddDiaryScreen(
                     )
                 )
                 coroutineScope.launch {
-                    delay(4000) // 테스트 해보니 피드백 생성 주로 3초대 소요
-                    onGetFeedbackBtnClick()
+                    delay(5000) // 테스트 해보니 피드백 생성 주로 3초대 소요
+                    onGetFeedbackBtnClick(date)
                 }
             }
         )

--- a/app/src/main/java/com/konkuk/strhat/feature/diary/AddDiaryViewModel.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/diary/AddDiaryViewModel.kt
@@ -6,11 +6,11 @@ import com.konkuk.strhat.R
 import com.konkuk.strhat.data.dto.request.RequestAddDiaryDto
 import com.konkuk.strhat.domain.entity.DiaryFeedbackModel
 import com.konkuk.strhat.domain.entity.EmotionType
+import com.konkuk.strhat.domain.entity.TotalDiaryModel
 import com.konkuk.strhat.domain.repository.DiaryRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import retrofit2.HttpException
@@ -33,8 +33,8 @@ class AddDiaryViewModel @Inject constructor(
     private val _diaryFeedbackState = MutableStateFlow(DiaryFeedbackModel("", emptyList(), emptyList(), ""))
     val diaryFeedbackState: StateFlow<DiaryFeedbackModel> = _diaryFeedbackState
 
-    private val _errorMessage = MutableStateFlow<String?>(null)
-    val errorMessage: StateFlow<String?> = _errorMessage.asStateFlow()
+    private val _totalDiaryState = MutableStateFlow(TotalDiaryModel(""))
+    val totalDiaryState: StateFlow<TotalDiaryModel> = _totalDiaryState
 
     fun postDiary(
         request: RequestAddDiaryDto
@@ -54,17 +54,38 @@ class AddDiaryViewModel @Inject constructor(
                         Timber.tag("save diary").d("일기 저장 성공")
                     }
                     .onFailure { error ->
-                        _errorMessage.update { error.message }
-
                         if (error is HttpException) {
                             val errorBody = error.response()?.errorBody()?.string()
-                            Timber.tag("save diary").e("서버 에러 메시지: $errorBody")
+                            Timber.tag("save diary").e("$errorBody")
                         } else {
                             Timber.tag("save diary").e(error, "일기 저장 실패")
                         }
                     }
             } catch (e: Exception) {
                 Timber.tag("save diary").e("일기 저장 서버 통신 오류")
+            }
+        }
+    }
+
+    fun getTotalDiary(
+        date: String
+    ) {
+        viewModelScope.launch {
+            try {
+                diaryRepository.getTotalDiary(date)
+                    .onSuccess { data ->
+                        _totalDiaryState.update {
+                            TotalDiaryModel(content = data.content)
+                        }
+                    }
+                    .onFailure { error ->
+                        if (error is HttpException) {
+                            val errorBody = error.response()?.errorBody()?.string()
+                            Timber.tag("get total diary").e("$errorBody")
+                        }
+                    }
+            } catch (e: Exception) {
+                Timber.tag("get total diary").e("일기 전문 보기 조회 오류")
             }
         }
     }

--- a/app/src/main/java/com/konkuk/strhat/feature/diary/AddDiaryViewModel.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/diary/AddDiaryViewModel.kt
@@ -1,13 +1,26 @@
 package com.konkuk.strhat.feature.diary
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.konkuk.strhat.R
+import com.konkuk.strhat.data.dto.request.RequestAddDiaryDto
+import com.konkuk.strhat.domain.entity.DiaryFeedbackModel
 import com.konkuk.strhat.domain.entity.EmotionType
+import com.konkuk.strhat.domain.repository.DiaryRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import retrofit2.HttpException
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
-class AddDiaryViewModel @Inject constructor() : ViewModel() {
+class AddDiaryViewModel @Inject constructor(
+    private val diaryRepository: DiaryRepository
+) : ViewModel() {
 
     val emotionTypes: List<EmotionType> = listOf(
         EmotionType(R.drawable.ic_strhat_blue, 1),
@@ -16,4 +29,43 @@ class AddDiaryViewModel @Inject constructor() : ViewModel() {
         EmotionType(R.drawable.ic_strhat_yellow, 4),
         EmotionType(R.drawable.ic_strhat_green, 5)
     )
+
+    private val _diaryFeedbackState = MutableStateFlow(DiaryFeedbackModel("", emptyList(), emptyList(), ""))
+    val diaryFeedbackState: StateFlow<DiaryFeedbackModel> = _diaryFeedbackState
+
+    private val _errorMessage = MutableStateFlow<String?>(null)
+    val errorMessage: StateFlow<String?> = _errorMessage.asStateFlow()
+
+    fun postDiary(
+        request: RequestAddDiaryDto
+    ) {
+        viewModelScope.launch {
+            try {
+                diaryRepository.postDiary(request)
+                    .onSuccess { data ->
+                        _diaryFeedbackState.update {
+                            DiaryFeedbackModel(
+                                summary = data.summary,
+                                positiveKeywords = data.positiveKeywords,
+                                negativeKeywords = data.negativeKeywords,
+                                stressReliefSuggestions = data.stressReliefSuggestions,
+                            )
+                        }
+                        Timber.tag("save diary").d("일기 저장 성공")
+                    }
+                    .onFailure { error ->
+                        _errorMessage.update { error.message }
+
+                        if (error is HttpException) {
+                            val errorBody = error.response()?.errorBody()?.string()
+                            Timber.tag("save diary").e("서버 에러 메시지: $errorBody")
+                        } else {
+                            Timber.tag("save diary").e(error, "일기 저장 실패")
+                        }
+                    }
+            } catch (e: Exception) {
+                Timber.tag("save diary").e("일기 저장 서버 통신 오류")
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/konkuk/strhat/feature/diary/AddDiaryViewModel.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/diary/AddDiaryViewModel.kt
@@ -36,6 +36,9 @@ class AddDiaryViewModel @Inject constructor(
     private val _totalDiaryState = MutableStateFlow(TotalDiaryModel(""))
     val totalDiaryState: StateFlow<TotalDiaryModel> = _totalDiaryState
 
+    val diaryContentState = MutableStateFlow("")
+    val selectedEmotionIndexState = MutableStateFlow(-1)
+
     fun postDiary(
         request: RequestAddDiaryDto
     ) {

--- a/app/src/main/java/com/konkuk/strhat/feature/diary/DiaryAIFeedbackRecordScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/diary/DiaryAIFeedbackRecordScreen.kt
@@ -226,37 +226,32 @@ fun DiaryAIFeedbackRecordScreen(
             val isDiaryRoute = previousRoute?.contains("Diary") == true
 
             StrHatButton(
-                isDisabled = isDiaryRoute,
+                isDisabled = false,
                 text =
                 if (isDiaryRoute)
-                    stringResource(R.string.diary_ai_feedback_quit_button)
+                    stringResource(R.string.confirm)
                 else
-                    stringResource(R.string.confirm),
+                    stringResource(R.string.diary_ai_feedback_quit_button),
                 modifier = Modifier
                     .padding(bottom = 20.dp)
                     .weight(1f),
-                onClick = {
-                    if (isDiaryRoute)
-                        navigateToTodayStressScore()
-                    else
-                        popBackStack()
-                }
+                onClick = popBackStack
             )
             StrHatButton(
                 isDisabled = false,
                 text =
                 if (previousRoute?.contains("Diary") == true)
-                    stringResource(R.string.diary_ai_feedback_chat_button)
+                    stringResource(R.string.my_page_ai_feedback_chat_history_button)
                 else
-                    stringResource(R.string.my_page_ai_feedback_chat_history_button),
+                    stringResource(R.string.diary_ai_feedback_chat_button),
                 modifier = Modifier
                     .padding(bottom = 20.dp)
                     .weight(1f),
                 onClick = {
                     if (previousRoute?.contains("Diary") == true)
-                        isChatModeBottomSheetVisible = true
-                    else
                         navigateToMyPageChatHistory()
+                    else
+                        isChatModeBottomSheetVisible = true
                 }
             )
         }

--- a/app/src/main/java/com/konkuk/strhat/feature/diary/DiaryAIFeedbackRecordScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/diary/DiaryAIFeedbackRecordScreen.kt
@@ -1,0 +1,288 @@
+package com.konkuk.strhat.feature.diary
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
+import com.konkuk.strhat.R
+import com.konkuk.strhat.core.component.SummaryBox
+import com.konkuk.strhat.core.component.bottomsheet.ChatModeBottomSheet
+import com.konkuk.strhat.core.component.button.StrHatButton
+import com.konkuk.strhat.core.component.button.UnderlineButton
+import com.konkuk.strhat.core.component.dialog.StrHatDialog
+import com.konkuk.strhat.core.component.section.PageDescriptionSection
+import com.konkuk.strhat.core.component.section.TitleSection
+import com.konkuk.strhat.core.util.modifier.noRippleClickable
+import com.konkuk.strhat.domain.entity.DiaryFeedbackModel
+import com.konkuk.strhat.domain.entity.TotalDiaryModel
+import com.konkuk.strhat.feature.diary.component.DiaryAIFeedbackKeywordBox
+import com.konkuk.strhat.feature.diary.component.DiaryAIFeedbackRecommendationBox
+import com.konkuk.strhat.ui.theme.StrHatTheme.colors
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.todayIn
+
+@Composable
+fun DiaryAIFeedbackRecordRoute(
+    padding: PaddingValues,
+    date: String,
+    navigateToChat: () -> Unit,
+    navigateToTodayStressScore: () -> Unit,
+    popBackStack: () -> Unit,
+    navigateToMyPageChatHistory: () -> Unit,
+    navController: NavController,
+    viewModel: DiaryViewModel = hiltViewModel(),
+    addDiaryViewModel: AddDiaryViewModel = hiltViewModel()
+) {
+    val diaryFeedbackState by viewModel.diaryFeedbackState.collectAsState()
+    val totalDiary by addDiaryViewModel.totalDiaryState.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.getDiaryFeedback(date)
+        addDiaryViewModel.getTotalDiary(date)
+    }
+
+    DiaryAIFeedbackRecordScreen(
+        padding = padding,
+        diaryFeedbackState = diaryFeedbackState,
+        totalDiary = totalDiary,
+        navigateToChat = navigateToChat,
+        navigateToTodayStressScore = navigateToTodayStressScore,
+        popBackStack = popBackStack,
+        navigateToMyPageChatHistory = navigateToMyPageChatHistory,
+        navController = navController
+    )
+}
+
+@Composable
+fun DiaryAIFeedbackRecordScreen(
+    padding: PaddingValues,
+    diaryFeedbackState: DiaryFeedbackModel,
+    totalDiary: TotalDiaryModel,
+    navigateToChat: () -> Unit,
+    navigateToTodayStressScore: () -> Unit,
+    popBackStack: () -> Unit,
+    navigateToMyPageChatHistory: () -> Unit,
+    navController: NavController,
+    modifier: Modifier = Modifier
+) {
+    val previousRoute = remember {
+        navController.previousBackStackEntry?.destination?.route
+    }
+
+    var showTotalDiaryDialog by remember { mutableStateOf(false) }
+    var isChatModeBottomSheetVisible by remember { mutableStateOf(false) }
+
+    val today = remember {
+        Clock.System.todayIn(TimeZone.currentSystemDefault())
+    }
+
+    val formattedDate = stringResource(
+        id = R.string.diary_ai_feedback_date,
+        today.year, today.monthNumber, today.dayOfMonth
+    )
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(colors.MainWhite)
+            .padding(top = 70.dp, start = 20.dp, end = 20.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .padding(bottom = 20.dp)
+                .verticalScroll(rememberScrollState())
+        ) {
+            PageDescriptionSection(
+                titleResId = R.string.diary_ai_feedback_screen_title
+            )
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                verticalAlignment = Alignment.Bottom,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                TitleSection(
+                    title = stringResource(
+                        id = R.string.diary_ai_feedback_date_title,
+                        formattedDate
+                    )
+                )
+
+                Spacer(modifier = Modifier.width(6.dp))
+
+                UnderlineButton(
+                    btnText = stringResource(R.string.diary_ai_total_diary_button),
+                    modifier = Modifier.noRippleClickable {
+                        showTotalDiaryDialog = true
+                    }
+                )
+            }
+
+            SummaryBox(
+                summary = diaryFeedbackState.summary,
+                backgroundColor = colors.Gray100,
+                modifier = Modifier.padding(top = 10.dp)
+            )
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            TitleSection(
+                title = stringResource(R.string.diary_ai_feedback_positive_title)
+            )
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(46.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                DiaryAIFeedbackKeywordBox(
+                    keywords = diaryFeedbackState.positiveKeywords,
+                    feedBackBoxBackgroundColor = colors.SubBlue,
+                    modifier = Modifier.weight(1f)
+                )
+                Image(
+                    painter = painterResource(R.drawable.ic_strhat_green_shadow),
+                    contentDescription = null,
+                    modifier = Modifier
+                        .padding(end = 24.dp)
+                        .width(100.dp)
+                )
+            }
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            TitleSection(
+                title = stringResource(R.string.diary_ai_feedback_negative_title)
+            )
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(46.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Image(
+                    painter = painterResource(R.drawable.ic_strhat_red_shadow),
+                    contentDescription = null,
+                    modifier = Modifier
+                        .padding(start = 24.dp)
+                        .width(100.dp)
+                )
+                DiaryAIFeedbackKeywordBox(
+                    keywords = diaryFeedbackState.negativeKeywords,
+                    feedBackBoxBackgroundColor = colors.Gray100,
+                    modifier = Modifier.weight(1f)
+                )
+            }
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            TitleSection(
+                title = stringResource(R.string.diary_ai_feedback_recommendation_title)
+            )
+
+            DiaryAIFeedbackRecommendationBox(
+                diaryAIFeedbackRecommendation = diaryFeedbackState.stressReliefSuggestions,
+                modifier = Modifier.padding(top = 10.dp)
+            )
+        }
+
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(40.dp)
+        ) {
+            val isDiaryRoute = previousRoute?.contains("Diary") == true
+
+            StrHatButton(
+                isDisabled = isDiaryRoute,
+                text =
+                if (isDiaryRoute)
+                    stringResource(R.string.diary_ai_feedback_quit_button)
+                else
+                    stringResource(R.string.confirm),
+                modifier = Modifier
+                    .padding(bottom = 20.dp)
+                    .weight(1f),
+                onClick = {
+                    if (isDiaryRoute)
+                        navigateToTodayStressScore()
+                    else
+                        popBackStack()
+                }
+            )
+            StrHatButton(
+                isDisabled = false,
+                text =
+                if (previousRoute?.contains("Diary") == true)
+                    stringResource(R.string.diary_ai_feedback_chat_button)
+                else
+                    stringResource(R.string.my_page_ai_feedback_chat_history_button),
+                modifier = Modifier
+                    .padding(bottom = 20.dp)
+                    .weight(1f),
+                onClick = {
+                    if (previousRoute?.contains("Diary") == true)
+                        isChatModeBottomSheetVisible = true
+                    else
+                        navigateToMyPageChatHistory()
+                }
+            )
+        }
+    }
+
+    if (showTotalDiaryDialog) {
+        Dialog(
+            onDismissRequest = { showTotalDiaryDialog = false }
+        ) {
+            StrHatDialog(
+                titleResId = R.string.diary_ai_total_diary_button,
+                diary = totalDiary.content,
+                onConfirmButtonClick = { showTotalDiaryDialog = false },
+                onDismissButtonClick = { showTotalDiaryDialog = false }
+            )
+        }
+    }
+
+    if (isChatModeBottomSheetVisible) {
+        ChatModeBottomSheet(
+            isVisible = isChatModeBottomSheetVisible,
+            onDismiss = { isChatModeBottomSheetVisible = false },
+            onChatModeSelected = { selectedMode ->
+                isChatModeBottomSheetVisible = false
+            },
+            navigateToChat = navigateToChat
+        )
+    }
+}

--- a/app/src/main/java/com/konkuk/strhat/feature/diary/DiaryAIFeedbackScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/diary/DiaryAIFeedbackScreen.kt
@@ -251,7 +251,7 @@ private fun DiaryAIFeedbackScreen(
             StrHatButton(
                 isDisabled = false,
                 text =
-                    if (previousRoute?.contains("Diary") == true)
+                    if (isDiaryRoute)
                         stringResource(R.string.diary_ai_feedback_chat_button)
                     else
                         stringResource(R.string.my_page_ai_feedback_chat_history_button),
@@ -259,7 +259,7 @@ private fun DiaryAIFeedbackScreen(
                     .padding(bottom = 20.dp)
                     .weight(1f),
                 onClick = {
-                    if (previousRoute?.contains("Diary") == true)
+                    if (isDiaryRoute)
                         isChatModeBottomSheetVisible = true
                     else
                         navigateToMyPageChatHistory()

--- a/app/src/main/java/com/konkuk/strhat/feature/diary/DiaryAIFeedbackScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/diary/DiaryAIFeedbackScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -40,6 +41,7 @@ import com.konkuk.strhat.core.component.section.PageDescriptionSection
 import com.konkuk.strhat.core.component.section.TitleSection
 import com.konkuk.strhat.core.util.modifier.noRippleClickable
 import com.konkuk.strhat.domain.entity.DiaryFeedbackModel
+import com.konkuk.strhat.domain.entity.TotalDiaryModel
 import com.konkuk.strhat.feature.diary.component.DiaryAIFeedbackKeywordBox
 import com.konkuk.strhat.feature.diary.component.DiaryAIFeedbackRecommendationBox
 import com.konkuk.strhat.feature.diary.state.DiaryAIFeedbackState
@@ -52,6 +54,7 @@ import kotlinx.datetime.todayIn
 @Composable
 fun DiaryAIFeedbackRoute(
     padding: PaddingValues,
+    date: String,
     diaryFeedbackModel: DiaryFeedbackModel,
     navigateToChat: () -> Unit,
     navigateToTodayStressScore: () -> Unit,
@@ -62,7 +65,11 @@ fun DiaryAIFeedbackRoute(
     addDiaryViewModel: AddDiaryViewModel = hiltViewModel()
 ) {
     val diaryAIFeedbackState by viewModel.diaryAIFeedbackState.collectAsState()
-    val totalDiary by viewModel.totalDiary.collectAsState()
+    val totalDiary by addDiaryViewModel.totalDiaryState.collectAsState()
+
+    LaunchedEffect(Unit) {
+        addDiaryViewModel.getTotalDiary(date)
+    }
 
     DiaryAIFeedbackScreen(
         padding = padding,
@@ -82,7 +89,7 @@ private fun DiaryAIFeedbackScreen(
     padding: PaddingValues,
     diaryFeedbackModel: DiaryFeedbackModel,
     diaryAIFeedbackState: DiaryAIFeedbackState,
-    totalDiary: String,
+    totalDiary: TotalDiaryModel,
     navigateToChat: () -> Unit,
     navigateToTodayStressScore: () -> Unit,
     popBackStack: () -> Unit,
@@ -267,7 +274,7 @@ private fun DiaryAIFeedbackScreen(
         ) {
             StrHatDialog(
                 titleResId = R.string.diary_ai_total_diary_button,
-                diary = totalDiary,
+                diary = totalDiary.content,
                 onConfirmButtonClick = { showTotalDiaryDialog = false },
                 onDismissButtonClick = { showTotalDiaryDialog = false }
             )
@@ -301,7 +308,7 @@ fun DiaryAIFeedbackScreenPreview() {
             padding = PaddingValues(),
             diaryFeedbackModel = DiaryFeedbackModel("", listOf(), listOf(), ""),
             diaryAIFeedbackState = diaryAIFeedbackExampleState,
-            totalDiary = stringResource(R.string.diary_ai_feedback_total_diary_example),
+            totalDiary = TotalDiaryModel(""),
             navigateToChat = {},
             navigateToTodayStressScore = {},
             popBackStack = {},

--- a/app/src/main/java/com/konkuk/strhat/feature/diary/DiaryAIFeedbackScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/diary/DiaryAIFeedbackScreen.kt
@@ -31,6 +31,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.konkuk.strhat.R
+import com.konkuk.strhat.core.component.SummaryBox
 import com.konkuk.strhat.core.component.bottomsheet.ChatModeBottomSheet
 import com.konkuk.strhat.core.component.button.StrHatButton
 import com.konkuk.strhat.core.component.button.UnderlineButton
@@ -38,9 +39,9 @@ import com.konkuk.strhat.core.component.dialog.StrHatDialog
 import com.konkuk.strhat.core.component.section.PageDescriptionSection
 import com.konkuk.strhat.core.component.section.TitleSection
 import com.konkuk.strhat.core.util.modifier.noRippleClickable
+import com.konkuk.strhat.domain.entity.DiaryFeedbackModel
 import com.konkuk.strhat.feature.diary.component.DiaryAIFeedbackKeywordBox
 import com.konkuk.strhat.feature.diary.component.DiaryAIFeedbackRecommendationBox
-import com.konkuk.strhat.core.component.SummaryBox
 import com.konkuk.strhat.feature.diary.state.DiaryAIFeedbackState
 import com.konkuk.strhat.ui.theme.StrHatTheme
 import com.konkuk.strhat.ui.theme.StrHatTheme.colors
@@ -51,18 +52,21 @@ import kotlinx.datetime.todayIn
 @Composable
 fun DiaryAIFeedbackRoute(
     padding: PaddingValues,
+    diaryFeedbackModel: DiaryFeedbackModel,
     navigateToChat: () -> Unit,
     navigateToTodayStressScore: () -> Unit,
     popBackStack: () -> Unit,
     navigateToMyPageChatHistory: () -> Unit,
     navController: NavController,
-    viewModel: DiaryAIFeedbackViewModel = hiltViewModel()
+    viewModel: DiaryAIFeedbackViewModel = hiltViewModel(),
+    addDiaryViewModel: AddDiaryViewModel = hiltViewModel()
 ) {
     val diaryAIFeedbackState by viewModel.diaryAIFeedbackState.collectAsState()
     val totalDiary by viewModel.totalDiary.collectAsState()
 
     DiaryAIFeedbackScreen(
         padding = padding,
+        diaryFeedbackModel = diaryFeedbackModel,
         diaryAIFeedbackState = diaryAIFeedbackState,
         totalDiary = totalDiary,
         navigateToChat = navigateToChat,
@@ -76,6 +80,7 @@ fun DiaryAIFeedbackRoute(
 @Composable
 private fun DiaryAIFeedbackScreen(
     padding: PaddingValues,
+    diaryFeedbackModel: DiaryFeedbackModel,
     diaryAIFeedbackState: DiaryAIFeedbackState,
     totalDiary: String,
     navigateToChat: () -> Unit,
@@ -143,7 +148,7 @@ private fun DiaryAIFeedbackScreen(
             }
 
             SummaryBox(
-                summary = diaryAIFeedbackState.diaryAIFeedbackSummary,
+                summary = diaryFeedbackModel.summary,
                 backgroundColor = colors.Gray100,
                 modifier = Modifier.padding(top = 10.dp)
             )
@@ -162,7 +167,7 @@ private fun DiaryAIFeedbackScreen(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 DiaryAIFeedbackKeywordBox(
-                    keywords = diaryAIFeedbackState.diaryAIFeedbackPositiveKeywords,
+                    keywords = diaryFeedbackModel.positiveKeywords,
                     feedBackBoxBackgroundColor = colors.SubBlue,
                     modifier = Modifier.weight(1f)
                 )
@@ -196,7 +201,7 @@ private fun DiaryAIFeedbackScreen(
                         .width(100.dp)
                 )
                 DiaryAIFeedbackKeywordBox(
-                    keywords = diaryAIFeedbackState.diaryAIFeedbackNegativeKeywords,
+                    keywords = diaryFeedbackModel.negativeKeywords,
                     feedBackBoxBackgroundColor = colors.Gray100,
                     modifier = Modifier.weight(1f)
                 )
@@ -209,7 +214,7 @@ private fun DiaryAIFeedbackScreen(
             )
 
             DiaryAIFeedbackRecommendationBox(
-                diaryAIFeedbackRecommendation = diaryAIFeedbackState.diaryAIFeedbackRecommendation,
+                diaryAIFeedbackRecommendation = diaryFeedbackModel.stressReliefSuggestions,
                 modifier = Modifier.padding(top = 10.dp)
             )
         }
@@ -294,6 +299,7 @@ fun DiaryAIFeedbackScreenPreview() {
 
         DiaryAIFeedbackScreen(
             padding = PaddingValues(),
+            diaryFeedbackModel = DiaryFeedbackModel("", listOf(), listOf(), ""),
             diaryAIFeedbackState = diaryAIFeedbackExampleState,
             totalDiary = stringResource(R.string.diary_ai_feedback_total_diary_example),
             navigateToChat = {},

--- a/app/src/main/java/com/konkuk/strhat/feature/diary/DiaryScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/diary/DiaryScreen.kt
@@ -1,6 +1,5 @@
 package com.konkuk.strhat.feature.diary
 
-import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -46,7 +45,6 @@ import com.konkuk.strhat.feature.diary.component.AddDiaryFloatingButton
 import com.konkuk.strhat.feature.diary.component.CalendarDateCell
 import com.konkuk.strhat.feature.diary.component.CalendarDayOfWeekCell
 import com.konkuk.strhat.feature.diary.component.DiaryDateUnselectedEmptyView
-import com.konkuk.strhat.feature.diary.component.DiaryDateUnselectedEmptyViewPreview
 import com.konkuk.strhat.feature.diary.component.DiarySummaryView
 import com.konkuk.strhat.feature.diary.component.NoDiaryEmptyView
 import com.konkuk.strhat.feature.diary.state.Diary
@@ -62,6 +60,7 @@ import java.time.YearMonth
 fun DiaryRoute(
     padding: PaddingValues,
     navigateToAddDiary: () -> Unit,
+    navigateToDiaryAIFeedback: (String) -> Unit,
     viewModel: DiaryViewModel = hiltViewModel()
 ) {
     val selectedDate by viewModel.selectedDate.collectAsState()
@@ -74,7 +73,8 @@ fun DiaryRoute(
         selectedDiary = selectedDiary,
         onDateSelected = viewModel::onDateSelected,
         diaryExistenceState = diaryExistenceState,
-        onFloatingBtnClick = navigateToAddDiary
+        onFloatingBtnClick = navigateToAddDiary,
+        onSummaryViewClick = navigateToDiaryAIFeedback
     )
 }
 
@@ -86,6 +86,7 @@ private fun DiaryScreen(
     onDateSelected: (LocalDate) -> Unit,
     diaryExistenceState: DiaryExistenceModel,
     onFloatingBtnClick: () -> Unit,
+    onSummaryViewClick: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Box(
@@ -194,7 +195,13 @@ private fun DiaryScreen(
                     DiaryDateUnselectedEmptyView()
                 }
                 diaryExistenceState.hasDiary -> {
-                    diaryExistenceState.summary?.let { DiarySummaryView(date = selectedDate, content = it) }
+                    diaryExistenceState.summary?.let {
+                        DiarySummaryView(
+                            date = selectedDate,
+                            content = it,
+                            onSummaryViewClick = { onSummaryViewClick(selectedDate.toString()) }
+                        )
+                    }
                 }
                 else -> {
                     NoDiaryEmptyView()
@@ -221,6 +228,7 @@ fun DiaryScreenPreview() {
         selectedDiary = Diary(LocalDate(2025, 1, 1), "ㅁㄴㅇㄹㅁㄴㅇㄹㅁㄴㅇㄹㅁㄴㅇㄹㅁㄴㅇㄹㅁㄴㅇㄹㅁㄴㅇㄹㅁㄴㅇㄹㅁㄴㅇㄹㅁㄴㅇㄹㅁㄴㅇㄹㅁㄴㅇㄹㅁㄴㅇㄹㅁㄴㅇㄹㅁㄴㅇㄹㅁㄴㅇㄹ"),
         diaryExistenceState = DiaryExistenceModel(true, 1, ""),
         onFloatingBtnClick = {},
+        onSummaryViewClick = {},
         onDateSelected = {}
     )
 }

--- a/app/src/main/java/com/konkuk/strhat/feature/diary/DiaryScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/diary/DiaryScreen.kt
@@ -1,5 +1,6 @@
 package com.konkuk.strhat.feature.diary
 
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -40,10 +41,12 @@ import com.konkuk.strhat.core.util.KeyStorage.FIRST_DAY_OF_MONTH
 import com.konkuk.strhat.core.util.KeyStorage.MIN_OFFSET
 import com.konkuk.strhat.core.util.KeyStorage.PLUS_MINUS_OF_MONTH
 import com.konkuk.strhat.core.util.modifier.noRippleClickable
+import com.konkuk.strhat.domain.entity.DiaryExistenceModel
 import com.konkuk.strhat.feature.diary.component.AddDiaryFloatingButton
 import com.konkuk.strhat.feature.diary.component.CalendarDateCell
 import com.konkuk.strhat.feature.diary.component.CalendarDayOfWeekCell
 import com.konkuk.strhat.feature.diary.component.DiaryDateUnselectedEmptyView
+import com.konkuk.strhat.feature.diary.component.DiaryDateUnselectedEmptyViewPreview
 import com.konkuk.strhat.feature.diary.component.DiarySummaryView
 import com.konkuk.strhat.feature.diary.component.NoDiaryEmptyView
 import com.konkuk.strhat.feature.diary.state.Diary
@@ -63,12 +66,14 @@ fun DiaryRoute(
 ) {
     val selectedDate by viewModel.selectedDate.collectAsState()
     val selectedDiary by viewModel.selectedDiary.collectAsState()
+    val diaryExistenceState by viewModel.diaryExistenceState.collectAsState()
 
     DiaryScreen(
         padding = padding,
         selectedDate = selectedDate,
         selectedDiary = selectedDiary,
         onDateSelected = viewModel::onDateSelected,
+        diaryExistenceState = diaryExistenceState,
         onFloatingBtnClick = navigateToAddDiary
     )
 }
@@ -79,6 +84,7 @@ private fun DiaryScreen(
     selectedDate: LocalDate?,
     selectedDiary: Diary?,
     onDateSelected: (LocalDate) -> Unit,
+    diaryExistenceState: DiaryExistenceModel,
     onFloatingBtnClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -187,8 +193,8 @@ private fun DiaryScreen(
                 selectedDate == null -> {
                     DiaryDateUnselectedEmptyView()
                 }
-                selectedDiary != null -> {
-                    DiarySummaryView(date = selectedDate, content = selectedDiary.content)
+                diaryExistenceState.hasDiary -> {
+                    diaryExistenceState.summary?.let { DiarySummaryView(date = selectedDate, content = it) }
                 }
                 else -> {
                     NoDiaryEmptyView()
@@ -213,6 +219,7 @@ fun DiaryScreenPreview() {
         padding = PaddingValues(0.dp),
         selectedDate = LocalDate(2025, 1, 1),
         selectedDiary = Diary(LocalDate(2025, 1, 1), "ㅁㄴㅇㄹㅁㄴㅇㄹㅁㄴㅇㄹㅁㄴㅇㄹㅁㄴㅇㄹㅁㄴㅇㄹㅁㄴㅇㄹㅁㄴㅇㄹㅁㄴㅇㄹㅁㄴㅇㄹㅁㄴㅇㄹㅁㄴㅇㄹㅁㄴㅇㄹㅁㄴㅇㄹㅁㄴㅇㄹㅁㄴㅇㄹ"),
+        diaryExistenceState = DiaryExistenceModel(true, 1, ""),
         onFloatingBtnClick = {},
         onDateSelected = {}
     )

--- a/app/src/main/java/com/konkuk/strhat/feature/diary/DiaryViewModel.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/diary/DiaryViewModel.kt
@@ -2,8 +2,8 @@ package com.konkuk.strhat.feature.diary
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.konkuk.strhat.core.util.time.generateDiaryContent
 import com.konkuk.strhat.domain.entity.DiaryExistenceModel
+import com.konkuk.strhat.domain.entity.DiaryFeedbackModel
 import com.konkuk.strhat.domain.repository.DiaryRepository
 import com.konkuk.strhat.feature.diary.state.Diary
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -29,6 +29,9 @@ class DiaryViewModel @Inject constructor(
 
     private val _diaryExistenceState = MutableStateFlow(DiaryExistenceModel(false, null, null))
     val diaryExistenceState: StateFlow<DiaryExistenceModel> = _diaryExistenceState
+
+    private val _diaryFeedbackState = MutableStateFlow(DiaryFeedbackModel("", emptyList(), emptyList(), ""))
+    val diaryFeedbackState: StateFlow<DiaryFeedbackModel> = _diaryFeedbackState
 
     fun onDateSelected(date: LocalDate) {
         _selectedDate.value = date
@@ -59,6 +62,36 @@ class DiaryViewModel @Inject constructor(
                     }
             } catch (e: Exception) {
                 Timber.tag("get diary existence").e("일기 존재 여부 확인 조회 오류")
+            }
+        }
+    }
+
+    fun getDiaryFeedback(
+        date: String
+    ) {
+        viewModelScope.launch {
+            try {
+                diaryRepository.getDiaryFeedback(date)
+                    .onSuccess { data ->
+                        _diaryFeedbackState.update {
+                            DiaryFeedbackModel(
+                                summary = data.summary,
+                                positiveKeywords = data.positiveKeywords,
+                                negativeKeywords = data.negativeKeywords,
+                                stressReliefSuggestions = data.stressReliefSuggestions
+                            )
+                        }
+                    }
+                    .onFailure {
+                        if (it is HttpException) {
+                            val errorBody = it.response()?.errorBody()?.string()
+                            Timber.tag("get diary feedback").e("$errorBody")
+                        } else {
+                            Timber.tag("get diary feedback").e(it, "피드백 조회 실패")
+                        }
+                    }
+            } catch (e: Exception) {
+                Timber.tag("get diary feedback").e("피드백 조회 서버 통신 오류")
             }
         }
     }

--- a/app/src/main/java/com/konkuk/strhat/feature/diary/DiaryViewModel.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/diary/DiaryViewModel.kt
@@ -1,35 +1,65 @@
 package com.konkuk.strhat.feature.diary
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.konkuk.strhat.core.util.time.generateDiaryContent
+import com.konkuk.strhat.domain.entity.DiaryExistenceModel
+import com.konkuk.strhat.domain.repository.DiaryRepository
 import com.konkuk.strhat.feature.diary.state.Diary
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import kotlinx.datetime.LocalDate
+import retrofit2.HttpException
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
-class DiaryViewModel @Inject constructor() : ViewModel() {
+class DiaryViewModel @Inject constructor(
+    private val diaryRepository: DiaryRepository
+) : ViewModel() {
     private val _selectedDate = MutableStateFlow<LocalDate?>(null)
     val selectedDate = _selectedDate.asStateFlow()
 
     private val _selectedDiary = MutableStateFlow<Diary?>(null)
     val selectedDiary = _selectedDiary.asStateFlow()
 
-    private val dummyDiary: Map<LocalDate, Diary> = mapOf(
-        LocalDate(2025, 3, 1) to Diary(
-            date = LocalDate(2025, 3, 1),
-            content = LocalDate(2025, 3, 1).generateDiaryContent()
-        ),
-        LocalDate(2025, 2, 26) to Diary(
-            date = LocalDate(2025, 2, 26),
-            content = LocalDate(2025, 2, 26).generateDiaryContent()
-        )
-    )
+    private val _diaryExistenceState = MutableStateFlow(DiaryExistenceModel(false, null, null))
+    val diaryExistenceState: StateFlow<DiaryExistenceModel> = _diaryExistenceState
 
     fun onDateSelected(date: LocalDate) {
         _selectedDate.value = date
-        _selectedDiary.value = dummyDiary[date]
+        getDiaryExistence(date.toString())
+        _selectedDiary.value = null
+    }
+
+    private fun getDiaryExistence(
+        date: String
+    ) {
+        viewModelScope.launch {
+            try {
+                diaryRepository.getDiaryExistence(date)
+                    .onSuccess { data ->
+                        _diaryExistenceState.update {
+                            DiaryExistenceModel(
+                                hasDiary = data.hasDiary,
+                                emotion = data.emotion,
+                                summary = data.summary
+                            )
+                        }
+                    }
+                    .onFailure {
+                        if (it is HttpException) {
+                            val errorBody = it.response()?.errorBody()?.string()
+                            Timber.tag("get diary existence").e("$errorBody")
+                        }
+                    }
+            } catch (e: Exception) {
+                Timber.tag("get diary existence").e("일기 존재 여부 확인 조회 오류")
+            }
+        }
     }
 }

--- a/app/src/main/java/com/konkuk/strhat/feature/diary/component/DiarySummaryView.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/diary/component/DiarySummaryView.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.konkuk.strhat.R
+import com.konkuk.strhat.core.util.modifier.noRippleClickable
 import com.konkuk.strhat.ui.theme.StrHatTheme
 import com.konkuk.strhat.ui.theme.StrHatTheme.colors
 import com.konkuk.strhat.ui.theme.StrHatTheme.typography
@@ -29,12 +30,14 @@ import kotlinx.datetime.LocalDate
 fun DiarySummaryView(
     date: LocalDate,
     content: String,
+    onSummaryViewClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
         modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = 20.dp)
+            .noRippleClickable(onSummaryViewClick)
     ) {
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -92,6 +95,7 @@ fun DiarySummaryViewPreview(
         DiarySummaryView(
             date = LocalDate(2025, 3, 11),
             content = "일기 내용 요약입니다 일기 내용 요약입니다 일기 내용 요약입니다 일기 내용 요약입니다 일기 내용 요약입니다 일기 내용 요약입니다 일기 내용 요약입니다",
+            onSummaryViewClick = {},
             modifier = modifier.background(colors.MainWhite)
         )
     }

--- a/app/src/main/java/com/konkuk/strhat/feature/diary/navigation/DiaryNavigation.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/diary/navigation/DiaryNavigation.kt
@@ -11,6 +11,7 @@ import com.konkuk.strhat.core.navigation.MainTabRoute
 import com.konkuk.strhat.domain.entity.DiaryFeedbackModel
 import com.konkuk.strhat.feature.diary.AddDiaryRoute
 import com.konkuk.strhat.feature.diary.ChatRoute
+import com.konkuk.strhat.feature.diary.DiaryAIFeedbackRecordRoute
 import com.konkuk.strhat.feature.diary.DiaryAIFeedbackRoute
 import com.konkuk.strhat.feature.diary.DiaryRoute
 import com.konkuk.strhat.feature.diary.TodayStressScoreRoute
@@ -38,6 +39,10 @@ fun NavController.navigateToDiaryAIFeedback(date: String, summary: String, posit
     }
 }
 
+fun NavController.navigateToDiaryAIFeedbackRecord(date: String) {
+    navigate(DiaryRoute.DiaryAIFeedbackRecord(date))
+}
+
 fun NavController.navigateToChat() {
     navigate(DiaryRoute.Chat)
 }
@@ -50,6 +55,7 @@ fun NavGraphBuilder.diaryNavGraph(
     padding: PaddingValues,
     onNavigateToAddDiary: () -> Unit,
     onNavigateToDiaryAIFeedback: (String, DiaryFeedbackModel) -> Unit,
+    onNavigateToDiaryAIFeedbackRecord: (String) -> Unit,
     onNavigateToChat: () -> Unit,
     onNavigateToHome: () -> Unit,
     onNavigateToMyPage: () -> Unit,
@@ -61,7 +67,8 @@ fun NavGraphBuilder.diaryNavGraph(
     composable<MainTabRoute.Diary> {
         DiaryRoute(
             padding = padding,
-            navigateToAddDiary = onNavigateToAddDiary
+            navigateToAddDiary = onNavigateToAddDiary,
+            navigateToDiaryAIFeedback = onNavigateToDiaryAIFeedbackRecord
         )
     }
 
@@ -90,6 +97,20 @@ fun NavGraphBuilder.diaryNavGraph(
             padding = padding,
             date = date,
             diaryFeedbackModel = diaryFeedbackModel,
+            navigateToChat = onNavigateToChat,
+            navigateToTodayStressScore = onNavigateToTodayStressScore,
+            popBackStack = onPopBackStack,
+            navigateToMyPageChatHistory = onNavigateToMyPageChatHistory,
+            navController = navController
+        )
+    }
+
+    composable<DiaryRoute.DiaryAIFeedbackRecord> { navBackStackEntry ->
+        val date = navBackStackEntry.toRoute<DiaryRoute.DiaryAIFeedbackRecord>().date
+
+        DiaryAIFeedbackRecordRoute(
+            padding = padding,
+            date = date,
             navigateToChat = onNavigateToChat,
             navigateToTodayStressScore = onNavigateToTodayStressScore,
             popBackStack = onPopBackStack,

--- a/app/src/main/java/com/konkuk/strhat/feature/diary/navigation/DiaryNavigation.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/diary/navigation/DiaryNavigation.kt
@@ -5,8 +5,10 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import androidx.navigation.toRoute
 import com.konkuk.strhat.core.navigation.DiaryRoute
 import com.konkuk.strhat.core.navigation.MainTabRoute
+import com.konkuk.strhat.domain.entity.DiaryFeedbackModel
 import com.konkuk.strhat.feature.diary.AddDiaryRoute
 import com.konkuk.strhat.feature.diary.ChatRoute
 import com.konkuk.strhat.feature.diary.DiaryAIFeedbackRoute
@@ -21,10 +23,16 @@ fun NavController.navigateToAddDiary() {
     navigate(DiaryRoute.AddDiary)
 }
 
-fun NavController.navigateToDiaryAIFeedback() {
-    navigate(DiaryRoute.DiaryAIFeedback) {
+fun NavController.navigateToMyPageDiaryAIFeedback() {
+    navigate(DiaryRoute.DiaryAIFeedback)
+}
+
+fun NavController.navigateToDiaryAIFeedback(summary: String, positiveKeywords: List<String>, negativeKeywords: List<String>, stressReliefSuggestions: String) {
+    navigate(
+        DiaryRoute.DiaryAIFeedback(summary, positiveKeywords, negativeKeywords, stressReliefSuggestions)
+    ) {
         popUpTo(MainTabRoute.Diary) {
-            inclusive = false
+            inclusive = true
         }
         launchSingleTop = true
     }
@@ -41,7 +49,7 @@ fun NavController.navigateToTodayStressScore() {
 fun NavGraphBuilder.diaryNavGraph(
     padding: PaddingValues,
     onNavigateToAddDiary: () -> Unit,
-    onNavigateToDiaryAIFeedback: () -> Unit,
+    onNavigateToDiaryAIFeedback: (DiaryFeedbackModel) -> Unit,
     onNavigateToChat: () -> Unit,
     onNavigateToHome: () -> Unit,
     onNavigateToMyPage: () -> Unit,
@@ -64,9 +72,22 @@ fun NavGraphBuilder.diaryNavGraph(
         )
     }
 
-    composable<DiaryRoute.DiaryAIFeedback> {
+    composable<DiaryRoute.DiaryAIFeedback> {navBackStackEntry ->
+        val summary = navBackStackEntry.toRoute<DiaryRoute.DiaryAIFeedback>().summary
+        val positiveKeywords = navBackStackEntry.toRoute<DiaryRoute.DiaryAIFeedback>().positiveKeywords
+        val negativeKeywords = navBackStackEntry.toRoute<DiaryRoute.DiaryAIFeedback>().negativeKeywords
+        val stressReliefSuggestions = navBackStackEntry.toRoute<DiaryRoute.DiaryAIFeedback>().stressReliefSuggestions
+
+        val diaryFeedbackModel = DiaryFeedbackModel(
+            summary = summary,
+            positiveKeywords = positiveKeywords,
+            negativeKeywords = negativeKeywords,
+            stressReliefSuggestions = stressReliefSuggestions
+        )
+
         DiaryAIFeedbackRoute(
             padding = padding,
+            diaryFeedbackModel = diaryFeedbackModel,
             navigateToChat = onNavigateToChat,
             navigateToTodayStressScore = onNavigateToTodayStressScore,
             popBackStack = onPopBackStack,

--- a/app/src/main/java/com/konkuk/strhat/feature/diary/navigation/DiaryNavigation.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/diary/navigation/DiaryNavigation.kt
@@ -27,9 +27,9 @@ fun NavController.navigateToMyPageDiaryAIFeedback() {
     navigate(DiaryRoute.DiaryAIFeedback)
 }
 
-fun NavController.navigateToDiaryAIFeedback(summary: String, positiveKeywords: List<String>, negativeKeywords: List<String>, stressReliefSuggestions: String) {
+fun NavController.navigateToDiaryAIFeedback(date: String, summary: String, positiveKeywords: List<String>, negativeKeywords: List<String>, stressReliefSuggestions: String) {
     navigate(
-        DiaryRoute.DiaryAIFeedback(summary, positiveKeywords, negativeKeywords, stressReliefSuggestions)
+        DiaryRoute.DiaryAIFeedback(date, summary, positiveKeywords, negativeKeywords, stressReliefSuggestions)
     ) {
         popUpTo(MainTabRoute.Diary) {
             inclusive = true
@@ -49,7 +49,7 @@ fun NavController.navigateToTodayStressScore() {
 fun NavGraphBuilder.diaryNavGraph(
     padding: PaddingValues,
     onNavigateToAddDiary: () -> Unit,
-    onNavigateToDiaryAIFeedback: (DiaryFeedbackModel) -> Unit,
+    onNavigateToDiaryAIFeedback: (String, DiaryFeedbackModel) -> Unit,
     onNavigateToChat: () -> Unit,
     onNavigateToHome: () -> Unit,
     onNavigateToMyPage: () -> Unit,
@@ -77,6 +77,7 @@ fun NavGraphBuilder.diaryNavGraph(
         val positiveKeywords = navBackStackEntry.toRoute<DiaryRoute.DiaryAIFeedback>().positiveKeywords
         val negativeKeywords = navBackStackEntry.toRoute<DiaryRoute.DiaryAIFeedback>().negativeKeywords
         val stressReliefSuggestions = navBackStackEntry.toRoute<DiaryRoute.DiaryAIFeedback>().stressReliefSuggestions
+        val date = navBackStackEntry.toRoute<DiaryRoute.DiaryAIFeedback>().date
 
         val diaryFeedbackModel = DiaryFeedbackModel(
             summary = summary,
@@ -87,6 +88,7 @@ fun NavGraphBuilder.diaryNavGraph(
 
         DiaryAIFeedbackRoute(
             padding = padding,
+            date = date,
             diaryFeedbackModel = diaryFeedbackModel,
             navigateToChat = onNavigateToChat,
             navigateToTodayStressScore = onNavigateToTodayStressScore,

--- a/app/src/main/java/com/konkuk/strhat/feature/main/MainNavigator.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/main/MainNavigator.kt
@@ -131,12 +131,14 @@ class MainNavigator(
     }
 
     fun navigateToDiaryAIFeedback(
+        date: String,
         summary: String,
         positiveKeywords: List<String>,
         negativeKeywords: List<String>,
         stressReliefSuggestions: String
     ) {
         navController.navigateToDiaryAIFeedback(
+            date = date,
             summary = summary,
             positiveKeywords = positiveKeywords,
             negativeKeywords = negativeKeywords,

--- a/app/src/main/java/com/konkuk/strhat/feature/main/MainNavigator.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/main/MainNavigator.kt
@@ -15,6 +15,7 @@ import com.konkuk.strhat.feature.diary.navigation.navigateToAddDiary
 import com.konkuk.strhat.feature.diary.navigation.navigateToChat
 import com.konkuk.strhat.feature.diary.navigation.navigateToDiary
 import com.konkuk.strhat.feature.diary.navigation.navigateToDiaryAIFeedback
+import com.konkuk.strhat.feature.diary.navigation.navigateToDiaryAIFeedbackRecord
 import com.konkuk.strhat.feature.diary.navigation.navigateToMyPageDiaryAIFeedback
 import com.konkuk.strhat.feature.diary.navigation.navigateToTodayStressScore
 import com.konkuk.strhat.feature.home.navigation.navigateToHome
@@ -188,6 +189,10 @@ class MainNavigator(
 
     fun navigateToMyPageChatHistory() {
         navController.navigateToMyPageChatHistory()
+    }
+
+    fun navigateToDiaryAIFeedbackRecord(date: String) {
+        navController.navigateToDiaryAIFeedbackRecord(date)
     }
 
     private inline fun <reified T : Route> isSameCurrentDestination(): Boolean =

--- a/app/src/main/java/com/konkuk/strhat/feature/main/MainNavigator.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/main/MainNavigator.kt
@@ -15,6 +15,7 @@ import com.konkuk.strhat.feature.diary.navigation.navigateToAddDiary
 import com.konkuk.strhat.feature.diary.navigation.navigateToChat
 import com.konkuk.strhat.feature.diary.navigation.navigateToDiary
 import com.konkuk.strhat.feature.diary.navigation.navigateToDiaryAIFeedback
+import com.konkuk.strhat.feature.diary.navigation.navigateToMyPageDiaryAIFeedback
 import com.konkuk.strhat.feature.diary.navigation.navigateToTodayStressScore
 import com.konkuk.strhat.feature.home.navigation.navigateToHome
 import com.konkuk.strhat.feature.login.navigation.navigateToLogin
@@ -125,8 +126,22 @@ class MainNavigator(
         navController.navigateToAddDiary()
     }
 
-    fun navigateToDiaryAIFeedback() {
-        navController.navigateToDiaryAIFeedback()
+    fun navigateToMyPageDiaryAIFeedback() {
+        navController.navigateToMyPageDiaryAIFeedback()
+    }
+
+    fun navigateToDiaryAIFeedback(
+        summary: String,
+        positiveKeywords: List<String>,
+        negativeKeywords: List<String>,
+        stressReliefSuggestions: String
+    ) {
+        navController.navigateToDiaryAIFeedback(
+            summary = summary,
+            positiveKeywords = positiveKeywords,
+            negativeKeywords = negativeKeywords,
+            stressReliefSuggestions = stressReliefSuggestions
+        )
     }
 
     fun navigateToChat() {

--- a/app/src/main/java/com/konkuk/strhat/feature/main/component/MainNavHost.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/main/component/MainNavHost.kt
@@ -39,12 +39,13 @@ fun MainNavHost(
             diaryNavGraph(
                 padding = padding,
                 onNavigateToAddDiary = navigator::navigateToAddDiary,
-                onNavigateToDiaryAIFeedback = {
+                onNavigateToDiaryAIFeedback = { date, feedback ->
                     navigator.navigateToDiaryAIFeedback(
-                        summary = it.summary,
-                        positiveKeywords = it.positiveKeywords,
-                        negativeKeywords = it.negativeKeywords,
-                        stressReliefSuggestions = it.stressReliefSuggestions
+                        date = date,
+                        summary = feedback.summary,
+                        positiveKeywords = feedback.positiveKeywords,
+                        negativeKeywords = feedback.negativeKeywords,
+                        stressReliefSuggestions = feedback.stressReliefSuggestions
                     )
                 },
                 onNavigateToChat = navigator::navigateToChat,

--- a/app/src/main/java/com/konkuk/strhat/feature/main/component/MainNavHost.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/main/component/MainNavHost.kt
@@ -39,7 +39,14 @@ fun MainNavHost(
             diaryNavGraph(
                 padding = padding,
                 onNavigateToAddDiary = navigator::navigateToAddDiary,
-                onNavigateToDiaryAIFeedback = navigator::navigateToDiaryAIFeedback,
+                onNavigateToDiaryAIFeedback = {
+                    navigator.navigateToDiaryAIFeedback(
+                        summary = it.summary,
+                        positiveKeywords = it.positiveKeywords,
+                        negativeKeywords = it.negativeKeywords,
+                        stressReliefSuggestions = it.stressReliefSuggestions
+                    )
+                },
                 onNavigateToChat = navigator::navigateToChat,
                 onNavigateToHome = navigator::navigateToHome,
                 onNavigateToMyPage = navigator::navigateToMyPage,
@@ -66,7 +73,7 @@ fun MainNavHost(
                 onNavigateToChangeGraph = navigator::navigateToChangeGraph,
                 onPopBackStack = navigator::popBackStack,
                 onNavigateToMyPageStressScore = navigator::navigateToMyPageStressScore,
-                onNavigateToMyPageAIFeedback = navigator::navigateToDiaryAIFeedback,
+                onNavigateToMyPageAIFeedback = navigator::navigateToMyPageDiaryAIFeedback,
                 navController = navigator.navController
             )
 

--- a/app/src/main/java/com/konkuk/strhat/feature/main/component/MainNavHost.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/main/component/MainNavHost.kt
@@ -54,6 +54,11 @@ fun MainNavHost(
                 onNavigateToTodayStressScore = navigator::navigateToTodayStressScore,
                 onPopBackStack = navigator::popBackStack,
                 onNavigateToMyPageChatHistory = navigator::navigateToMyPageChatHistory,
+                onNavigateToDiaryAIFeedbackRecord = { date ->
+                    navigator.navigateToDiaryAIFeedbackRecord(
+                        date = date
+                    )
+                },
                 navController = navigator.navController
             )
 


### PR DESCRIPTION
## Related issue 🛠
- closed #23 

## Work Description 📝
- 작성된 일기 존재 여부 확인 API 연동
- 일기 저장 (피드백 응답 포함) API 연동
- 일기 조회 - 일기 전문 보기 API 연동
- 일기 피드백 조회 API 연동
- 일기 캘린더 요약 -> 피드백 뷰 네비게이션 분기처리 (피드백 뷰 가는 경우의 수 3가지)

## Screenshot 📸

https://github.com/user-attachments/assets/a8daf36b-ec1f-4daa-b4cf-d5cbcaae7b53



## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
일기 서버통신 구현 완료했습니다. 
아직 마이페이지에서의 피드백 조회는 연동하지 않았는데,
우선 API 연결 및 테스트를 위한 구현까지 진행했습니다.
다음 PR에서 마이페이지 적용이랑 자잘한 상세 수정까지 들어갈게요!