### PR TITLE
[Feat/#28, #30] 회원가입, 카카오 로그인, 토큰 / 마이페이지 관련 서버 통신 구현

### DIFF
--- a/app/src/main/java/com/konkuk/strhat/core/network/TokenAuthenticator.kt
+++ b/app/src/main/java/com/konkuk/strhat/core/network/TokenAuthenticator.kt
@@ -1,0 +1,55 @@
+package com.konkuk.strhat.core.network
+
+import com.konkuk.strhat.data.dto.request.RequestReissueTokenDto
+import com.konkuk.strhat.data.service.ReIssueService
+import okhttp3.Authenticator
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.Route
+import retrofit2.Retrofit
+import timber.log.Timber
+import javax.inject.Inject
+
+class TokenAuthenticator @Inject constructor(
+    private val tokenManager: TokenManager,
+    retrofit: Retrofit
+) : Authenticator {
+
+    private val authService = retrofit.create(ReIssueService::class.java)
+
+    override fun authenticate(route: Route?, response: Response): Request? {
+        val refreshToken = tokenManager.getRefreshToken()
+        if (refreshToken.isBlank()) return null
+
+        Timber.tag("TokenAuthenticator").d("401 감지됨. 토큰 재발급 시도")
+
+        val refreshTokenDto = RequestReissueTokenDto("Bearer $refreshToken")
+
+        val tokenResponse = authService.reissueToken(refreshTokenDto).execute()
+
+        return if (tokenResponse.isSuccessful) {
+            val newAccessToken = tokenResponse.headers()["authorization"]?.let {
+                it.removePrefix("Bearer").trim()
+            }
+            val newRefreshToken = tokenResponse.headers()["refresh-token"]?.let {
+                it.removePrefix("Bearer").trim()
+            }
+
+            if (newAccessToken.isNullOrBlank() || newRefreshToken.isNullOrBlank()) {
+                Timber.tag("TokenAuthenticator").e("헤더에서 토큰을 읽을 수 없음 → 로그인 필요")
+                return null
+            }
+
+            tokenManager.saveToken(newAccessToken)
+            tokenManager.saveRefreshToken(newRefreshToken)
+
+            response.request.newBuilder()
+                .header("Authorization", "Bearer $newAccessToken")
+                .build()
+        } else {
+            Timber.tag("TokenAuthenticator").e("토큰 재발급 실패 → 로그인 필요")
+            tokenManager.triggerLogout()
+            null
+        }
+    }
+}

--- a/app/src/main/java/com/konkuk/strhat/core/network/TokenAuthenticator.kt
+++ b/app/src/main/java/com/konkuk/strhat/core/network/TokenAuthenticator.kt
@@ -12,10 +12,8 @@ import javax.inject.Inject
 
 class TokenAuthenticator @Inject constructor(
     private val tokenManager: TokenManager,
-    retrofit: Retrofit
+    private val retrofit: dagger.Lazy<Retrofit>
 ) : Authenticator {
-
-    private val authService = retrofit.create(ReIssueService::class.java)
 
     override fun authenticate(route: Route?, response: Response): Request? {
         val refreshToken = tokenManager.getRefreshToken()
@@ -23,6 +21,7 @@ class TokenAuthenticator @Inject constructor(
 
         Timber.tag("TokenAuthenticator").d("401 감지됨. 토큰 재발급 시도")
 
+        val authService = retrofit.get().create(ReIssueService::class.java)
         val refreshTokenDto = RequestReissueTokenDto("Bearer $refreshToken")
 
         val tokenResponse = authService.reissueToken(refreshTokenDto).execute()

--- a/app/src/main/java/com/konkuk/strhat/core/network/TokenManager.kt
+++ b/app/src/main/java/com/konkuk/strhat/core/network/TokenManager.kt
@@ -37,4 +37,18 @@ class TokenManager @Inject constructor(
     fun saveKakaoId(kakaoId: Long) {
         sharedPreferences.edit().putLong(KEY_KAKAO_ID, kakaoId).apply()
     }
+
+    fun clear() {
+        sharedPreferences.edit().clear().apply()
+    }
+
+    private var onLogoutCallback: (() -> Unit)? = null
+
+    fun setLogoutCallback(callback: () -> Unit) {
+        onLogoutCallback = callback
+    }
+
+    fun triggerLogout() {
+        onLogoutCallback?.invoke()
+    }
 }

--- a/app/src/main/java/com/konkuk/strhat/core/util/AppRestartUtil.kt
+++ b/app/src/main/java/com/konkuk/strhat/core/util/AppRestartUtil.kt
@@ -1,28 +1,16 @@
 package com.konkuk.strhat.core.util
 
-import android.app.AlarmManager
-import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import com.konkuk.strhat.feature.main.MainActivity
-import kotlin.system.exitProcess
 
 object AppRestartUtil {
     fun restartApp(context: Context) {
         val intent = Intent(context, MainActivity::class.java).apply {
-            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or
+                    Intent.FLAG_ACTIVITY_CLEAR_TASK or
+                    Intent.FLAG_ACTIVITY_CLEAR_TOP
         }
-
-        val pendingIntent = PendingIntent.getActivity(
-            context,
-            0,
-            intent,
-            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_CANCEL_CURRENT
-        )
-
-        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
-        alarmManager.set(AlarmManager.RTC, System.currentTimeMillis() + 100, pendingIntent)
-
-        exitProcess(0)
+        context.startActivity(intent)
     }
 }

--- a/app/src/main/java/com/konkuk/strhat/core/util/AppRestartUtil.kt
+++ b/app/src/main/java/com/konkuk/strhat/core/util/AppRestartUtil.kt
@@ -1,0 +1,28 @@
+package com.konkuk.strhat.core.util
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import com.konkuk.strhat.feature.main.MainActivity
+import kotlin.system.exitProcess
+
+object AppRestartUtil {
+    fun restartApp(context: Context) {
+        val intent = Intent(context, MainActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+        }
+
+        val pendingIntent = PendingIntent.getActivity(
+            context,
+            0,
+            intent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_CANCEL_CURRENT
+        )
+
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        alarmManager.set(AlarmManager.RTC, System.currentTimeMillis() + 100, pendingIntent)
+
+        exitProcess(0)
+    }
+}

--- a/app/src/main/java/com/konkuk/strhat/data/datasource/AuthDataSource.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/datasource/AuthDataSource.kt
@@ -2,11 +2,11 @@ package com.konkuk.strhat.data.datasource
 
 import com.konkuk.strhat.data.dto.base.BaseResponse
 import com.konkuk.strhat.data.dto.request.RequestSignUpDto
-import com.konkuk.strhat.data.dto.request.RequestkakaoLoginDto
+import com.konkuk.strhat.data.dto.request.RequestKakaoLoginDto
 import com.konkuk.strhat.data.dto.response.ResponseKakaoLoginDto
 import retrofit2.Response
 
 interface AuthDataSource{
-    suspend fun postKakaoLogin(kakaoAccessToken: RequestkakaoLoginDto): Response<BaseResponse<ResponseKakaoLoginDto>>
+    suspend fun postKakaoLogin(kakaoAccessToken: RequestKakaoLoginDto): Response<BaseResponse<ResponseKakaoLoginDto>>
     suspend fun postSignUp(signUpRequest: RequestSignUpDto): Response<Unit>
 }

--- a/app/src/main/java/com/konkuk/strhat/data/datasource/AuthDataSource.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/datasource/AuthDataSource.kt
@@ -9,4 +9,5 @@ import retrofit2.Response
 interface AuthDataSource{
     suspend fun postKakaoLogin(kakaoAccessToken: RequestKakaoLoginDto): Response<BaseResponse<ResponseKakaoLoginDto>>
     suspend fun postSignUp(signUpRequest: RequestSignUpDto): Response<Unit>
+    suspend fun postSignOut(): Response<Unit>
 }

--- a/app/src/main/java/com/konkuk/strhat/data/datasource/UserDataSource.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/datasource/UserDataSource.kt
@@ -2,7 +2,10 @@ package com.konkuk.strhat.data.datasource
 
 import com.konkuk.strhat.data.dto.base.BaseResponse
 import com.konkuk.strhat.data.dto.response.ResponseUserInfoDto
+import retrofit2.Response
 
 interface UserDataSource {
     suspend fun getUserInfo(): BaseResponse<ResponseUserInfoDto>
+    suspend fun patchHobbyHealingInfo(hobbyHealingStyle: String): Response<Unit>
+
 }

--- a/app/src/main/java/com/konkuk/strhat/data/datasource/UserDataSource.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/datasource/UserDataSource.kt
@@ -1,0 +1,8 @@
+package com.konkuk.strhat.data.datasource
+
+import com.konkuk.strhat.data.dto.base.BaseResponse
+import com.konkuk.strhat.data.dto.response.ResponseUserInfoDto
+
+interface UserDataSource {
+    suspend fun getUserInfo(): BaseResponse<ResponseUserInfoDto>
+}

--- a/app/src/main/java/com/konkuk/strhat/data/datasource/UserDataSource.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/datasource/UserDataSource.kt
@@ -7,5 +7,5 @@ import retrofit2.Response
 interface UserDataSource {
     suspend fun getUserInfo(): BaseResponse<ResponseUserInfoDto>
     suspend fun patchHobbyHealingInfo(hobbyHealingStyle: String): Response<Unit>
-
+    suspend fun patchStressReliefInfo(stressReliefStyle: String): Response<Unit>
 }

--- a/app/src/main/java/com/konkuk/strhat/data/datasource/UserDataSource.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/datasource/UserDataSource.kt
@@ -8,4 +8,5 @@ interface UserDataSource {
     suspend fun getUserInfo(): BaseResponse<ResponseUserInfoDto>
     suspend fun patchHobbyHealingInfo(hobbyHealingStyle: String): Response<Unit>
     suspend fun patchStressReliefInfo(stressReliefStyle: String): Response<Unit>
+    suspend fun patchPersonalityInfo(personality: String): Response<Unit>
 }

--- a/app/src/main/java/com/konkuk/strhat/data/datasource/UserDataSource.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/datasource/UserDataSource.kt
@@ -1,11 +1,13 @@
 package com.konkuk.strhat.data.datasource
 
 import com.konkuk.strhat.data.dto.base.BaseResponse
+import com.konkuk.strhat.data.dto.request.RequestUserInfoDto
 import com.konkuk.strhat.data.dto.response.ResponseUserInfoDto
 import retrofit2.Response
 
 interface UserDataSource {
     suspend fun getUserInfo(): BaseResponse<ResponseUserInfoDto>
+    suspend fun patchUserInfo(userInfo: RequestUserInfoDto): Response<Unit>
     suspend fun patchHobbyHealingInfo(hobbyHealingStyle: String): Response<Unit>
     suspend fun patchStressReliefInfo(stressReliefStyle: String): Response<Unit>
     suspend fun patchPersonalityInfo(personality: String): Response<Unit>

--- a/app/src/main/java/com/konkuk/strhat/data/datasourceimpl/AuthDataSourceImpl.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/datasourceimpl/AuthDataSourceImpl.kt
@@ -3,7 +3,7 @@ package com.konkuk.strhat.data.datasourceimpl
 import com.konkuk.strhat.data.datasource.AuthDataSource
 import com.konkuk.strhat.data.dto.base.BaseResponse
 import com.konkuk.strhat.data.dto.request.RequestSignUpDto
-import com.konkuk.strhat.data.dto.request.RequestkakaoLoginDto
+import com.konkuk.strhat.data.dto.request.RequestKakaoLoginDto
 import com.konkuk.strhat.data.dto.response.ResponseKakaoLoginDto
 import com.konkuk.strhat.data.service.AuthService
 import retrofit2.Response
@@ -12,7 +12,7 @@ import javax.inject.Inject
 class AuthDataSourceImpl @Inject constructor(
     private val authService: AuthService
 ): AuthDataSource {
-    override suspend fun postKakaoLogin(kakaoAccessToken: RequestkakaoLoginDto): Response<BaseResponse<ResponseKakaoLoginDto>> =
+    override suspend fun postKakaoLogin(kakaoAccessToken: RequestKakaoLoginDto): Response<BaseResponse<ResponseKakaoLoginDto>> =
         authService.kakaoLogin(kakaoLoginRequest = kakaoAccessToken)
 
     override suspend fun postSignUp(signUpRequest: RequestSignUpDto): Response<Unit> =

--- a/app/src/main/java/com/konkuk/strhat/data/datasourceimpl/AuthDataSourceImpl.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/datasourceimpl/AuthDataSourceImpl.kt
@@ -18,4 +18,7 @@ class AuthDataSourceImpl @Inject constructor(
     override suspend fun postSignUp(signUpRequest: RequestSignUpDto): Response<Unit> =
         authService.signUp(signUpRequest = signUpRequest)
 
+    override suspend fun postSignOut(): Response<Unit> =
+        authService.signOut()
+
 }

--- a/app/src/main/java/com/konkuk/strhat/data/datasourceimpl/UserDataSourceImpl.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/datasourceimpl/UserDataSourceImpl.kt
@@ -3,6 +3,7 @@ package com.konkuk.strhat.data.datasourceimpl
 import com.konkuk.strhat.data.datasource.UserDataSource
 import com.konkuk.strhat.data.dto.base.BaseResponse
 import com.konkuk.strhat.data.dto.request.RequestHobbyHealingDto
+import com.konkuk.strhat.data.dto.request.RequestStressReliefDto
 import com.konkuk.strhat.data.dto.response.ResponseUserInfoDto
 import com.konkuk.strhat.data.service.UserService
 import retrofit2.Response
@@ -16,5 +17,8 @@ class UserDataSourceImpl @Inject constructor(
 
     override suspend fun patchHobbyHealingInfo(hobbyHealingStyle: String): Response<Unit> =
         userService.patchHobbyHealingInfo(RequestHobbyHealingDto(hobbyHealingStyle))
+
+    override suspend fun patchStressReliefInfo(stressReliefStyle: String): Response<Unit> =
+        userService.patchStressReliefInfo(RequestStressReliefDto(stressReliefStyle))
 
 }

--- a/app/src/main/java/com/konkuk/strhat/data/datasourceimpl/UserDataSourceImpl.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/datasourceimpl/UserDataSourceImpl.kt
@@ -2,8 +2,10 @@ package com.konkuk.strhat.data.datasourceimpl
 
 import com.konkuk.strhat.data.datasource.UserDataSource
 import com.konkuk.strhat.data.dto.base.BaseResponse
+import com.konkuk.strhat.data.dto.request.RequestHobbyHealingDto
 import com.konkuk.strhat.data.dto.response.ResponseUserInfoDto
 import com.konkuk.strhat.data.service.UserService
+import retrofit2.Response
 import javax.inject.Inject
 
 class UserDataSourceImpl @Inject constructor(
@@ -11,5 +13,8 @@ class UserDataSourceImpl @Inject constructor(
 ): UserDataSource {
     override suspend fun getUserInfo(): BaseResponse<ResponseUserInfoDto> =
         userService.getUserInfo()
+
+    override suspend fun patchHobbyHealingInfo(hobbyHealingStyle: String): Response<Unit> =
+        userService.patchHobbyHealingInfo(RequestHobbyHealingDto(hobbyHealingStyle))
 
 }

--- a/app/src/main/java/com/konkuk/strhat/data/datasourceimpl/UserDataSourceImpl.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/datasourceimpl/UserDataSourceImpl.kt
@@ -1,0 +1,15 @@
+package com.konkuk.strhat.data.datasourceimpl
+
+import com.konkuk.strhat.data.datasource.UserDataSource
+import com.konkuk.strhat.data.dto.base.BaseResponse
+import com.konkuk.strhat.data.dto.response.ResponseUserInfoDto
+import com.konkuk.strhat.data.service.UserService
+import javax.inject.Inject
+
+class UserDataSourceImpl @Inject constructor(
+    private val userService: UserService
+): UserDataSource {
+    override suspend fun getUserInfo(): BaseResponse<ResponseUserInfoDto> =
+        userService.getUserInfo()
+
+}

--- a/app/src/main/java/com/konkuk/strhat/data/datasourceimpl/UserDataSourceImpl.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/datasourceimpl/UserDataSourceImpl.kt
@@ -5,6 +5,7 @@ import com.konkuk.strhat.data.dto.base.BaseResponse
 import com.konkuk.strhat.data.dto.request.RequestHobbyHealingDto
 import com.konkuk.strhat.data.dto.request.RequestPersonalityDto
 import com.konkuk.strhat.data.dto.request.RequestStressReliefDto
+import com.konkuk.strhat.data.dto.request.RequestUserInfoDto
 import com.konkuk.strhat.data.dto.response.ResponseUserInfoDto
 import com.konkuk.strhat.data.service.UserService
 import retrofit2.Response
@@ -15,6 +16,9 @@ class UserDataSourceImpl @Inject constructor(
 ): UserDataSource {
     override suspend fun getUserInfo(): BaseResponse<ResponseUserInfoDto> =
         userService.getUserInfo()
+
+    override suspend fun patchUserInfo(userInfo: RequestUserInfoDto): Response<Unit> =
+        userService.patchUserInfo(userInfo)
 
     override suspend fun patchHobbyHealingInfo(hobbyHealingStyle: String): Response<Unit> =
         userService.patchHobbyHealingInfo(RequestHobbyHealingDto(hobbyHealingStyle))

--- a/app/src/main/java/com/konkuk/strhat/data/datasourceimpl/UserDataSourceImpl.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/datasourceimpl/UserDataSourceImpl.kt
@@ -3,6 +3,7 @@ package com.konkuk.strhat.data.datasourceimpl
 import com.konkuk.strhat.data.datasource.UserDataSource
 import com.konkuk.strhat.data.dto.base.BaseResponse
 import com.konkuk.strhat.data.dto.request.RequestHobbyHealingDto
+import com.konkuk.strhat.data.dto.request.RequestPersonalityDto
 import com.konkuk.strhat.data.dto.request.RequestStressReliefDto
 import com.konkuk.strhat.data.dto.response.ResponseUserInfoDto
 import com.konkuk.strhat.data.service.UserService
@@ -20,5 +21,8 @@ class UserDataSourceImpl @Inject constructor(
 
     override suspend fun patchStressReliefInfo(stressReliefStyle: String): Response<Unit> =
         userService.patchStressReliefInfo(RequestStressReliefDto(stressReliefStyle))
+
+    override suspend fun patchPersonalityInfo(personality: String): Response<Unit> =
+        userService.patchPersonalityInfo(RequestPersonalityDto(personality))
 
 }

--- a/app/src/main/java/com/konkuk/strhat/data/di/ApiModule.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/di/ApiModule.kt
@@ -3,6 +3,8 @@ package com.konkuk.strhat.data.di
 import com.konkuk.strhat.data.service.AuthService
 import com.konkuk.strhat.data.service.DiaryService
 import com.konkuk.strhat.data.service.HomeService
+import com.konkuk.strhat.data.service.ReIssueService
+import com.konkuk.strhat.data.service.UserService
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -27,4 +29,14 @@ object ApiModule {
     @Singleton
     fun providesAuthService(retrofit: Retrofit): AuthService =
         retrofit.create(AuthService::class.java)
+
+    @Provides
+    @Singleton
+    fun providesReIssueService(retrofit: Retrofit): ReIssueService =
+        retrofit.create(ReIssueService::class.java)
+
+    @Provides
+    @Singleton
+    fun providesUserService(retrofit: Retrofit): UserService =
+        retrofit.create(UserService::class.java)
 }

--- a/app/src/main/java/com/konkuk/strhat/data/di/DataSourceModule.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/di/DataSourceModule.kt
@@ -3,9 +3,11 @@ package com.konkuk.strhat.data.di
 import com.konkuk.strhat.data.datasource.AuthDataSource
 import com.konkuk.strhat.data.datasource.DiaryDataSource
 import com.konkuk.strhat.data.datasource.HomeDataSource
+import com.konkuk.strhat.data.datasource.UserDataSource
 import com.konkuk.strhat.data.datasourceimpl.AuthDataSourceImpl
 import com.konkuk.strhat.data.datasourceimpl.DiaryDataSourceImpl
 import com.konkuk.strhat.data.datasourceimpl.HomeDataSourceImpl
+import com.konkuk.strhat.data.datasourceimpl.UserDataSourceImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -26,4 +28,8 @@ abstract class DataSourceModule {
     @Binds
     @Singleton
     abstract fun bindsAuthDataSource(authDataSourceImpl: AuthDataSourceImpl): AuthDataSource
+
+    @Binds
+    @Singleton
+    abstract fun bindsUserDataSource(userDataSourceImpl: UserDataSourceImpl): UserDataSource
 }

--- a/app/src/main/java/com/konkuk/strhat/data/di/NetworkModule.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/di/NetworkModule.kt
@@ -2,6 +2,7 @@ package com.konkuk.strhat.data.di
 
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import com.konkuk.strhat.BuildConfig
+import com.konkuk.strhat.core.network.TokenAuthenticator
 import com.konkuk.strhat.core.network.TokenManager
 import dagger.Module
 import dagger.Provides
@@ -44,6 +45,13 @@ object NetworkModule {
         chain.proceed(newRequest)
     }
 
+    @Provides
+    @Singleton
+    fun providesTokenAuthenticator(
+        tokenManager: TokenManager,
+        retrofit: Retrofit
+    ): TokenAuthenticator = TokenAuthenticator(tokenManager, retrofit)
+
     private fun shouldAddAuthorization(url: String): Boolean {
         return !url.contains("/api/v1/auth/kakao") &&
                 !url.contains("/api/v1/users/sign-up")
@@ -53,10 +61,12 @@ object NetworkModule {
     @Singleton
     fun providesOkHttpClient(
         loggingInterceptor: HttpLoggingInterceptor,
-        authorizationInterceptor: okhttp3.Interceptor
+        authorizationInterceptor: okhttp3.Interceptor,
+        tokenAuthenticator: TokenAuthenticator
     ): OkHttpClient = OkHttpClient.Builder()
         .addInterceptor(loggingInterceptor)
         .addInterceptor(authorizationInterceptor)
+        .authenticator(tokenAuthenticator)
         .build()
 
     @Provides

--- a/app/src/main/java/com/konkuk/strhat/data/di/NetworkModule.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/di/NetworkModule.kt
@@ -40,7 +40,7 @@ object NetworkModule {
         val token = tokenManager.getToken()
 
         val newRequest = chain.request().newBuilder()
-            .addHeader("Authorization", "Bearer $token")
+            .addHeader("Authorization", token)
             .build()
         chain.proceed(newRequest)
     }
@@ -49,7 +49,7 @@ object NetworkModule {
     @Singleton
     fun providesTokenAuthenticator(
         tokenManager: TokenManager,
-        retrofit: Retrofit
+        retrofit: dagger.Lazy<Retrofit>
     ): TokenAuthenticator = TokenAuthenticator(tokenManager, retrofit)
 
     private fun shouldAddAuthorization(url: String): Boolean {

--- a/app/src/main/java/com/konkuk/strhat/data/di/RepositoryModule.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/di/RepositoryModule.kt
@@ -3,9 +3,11 @@ package com.konkuk.strhat.data.di
 import com.konkuk.strhat.data.repositoryimpl.AuthRepositoryImpl
 import com.konkuk.strhat.data.repositoryimpl.DiaryRepositoryImpl
 import com.konkuk.strhat.data.repositoryimpl.HomeRepositoryImpl
+import com.konkuk.strhat.data.repositoryimpl.UserRepositoryImpl
 import com.konkuk.strhat.domain.repository.AuthRepository
 import com.konkuk.strhat.domain.repository.DiaryRepository
 import com.konkuk.strhat.domain.repository.HomeRepository
+import com.konkuk.strhat.domain.repository.UserRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -26,4 +28,8 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindsAuthRepository(authRepositoryImpl: AuthRepositoryImpl): AuthRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindsUserRepository(userRepositoryImpl: UserRepositoryImpl): UserRepository
 }

--- a/app/src/main/java/com/konkuk/strhat/data/di/UseCaseModule.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/di/UseCaseModule.kt
@@ -2,6 +2,8 @@ package com.konkuk.strhat.data.di
 
 import com.konkuk.strhat.domain.repository.AuthRepository
 import com.konkuk.strhat.domain.repository.HomeRepository
+import com.konkuk.strhat.domain.repository.UserRepository
+import com.konkuk.strhat.domain.usecase.GetUserInfoUseCase
 import com.konkuk.strhat.domain.usecase.HomeUseCase
 import com.konkuk.strhat.domain.usecase.KakaoLoginUseCase
 import com.konkuk.strhat.domain.usecase.SignUpUseCase
@@ -31,4 +33,10 @@ object UseCaseModule {
     fun providesSignUpUseCase(
         authRepository: AuthRepository
     ): SignUpUseCase = SignUpUseCase(authRepository)
+
+    @Provides
+    @Singleton
+    fun providesGetUserInfoUseCase(
+        userRepository: UserRepository
+    ): GetUserInfoUseCase = GetUserInfoUseCase(userRepository)
 }

--- a/app/src/main/java/com/konkuk/strhat/data/di/UseCaseModule.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/di/UseCaseModule.kt
@@ -7,6 +7,7 @@ import com.konkuk.strhat.domain.usecase.GetUserInfoUseCase
 import com.konkuk.strhat.domain.usecase.HomeUseCase
 import com.konkuk.strhat.domain.usecase.KakaoLoginUseCase
 import com.konkuk.strhat.domain.usecase.PatchHobbyHealingInfoUseCase
+import com.konkuk.strhat.domain.usecase.PatchPersonalityInfoUseCase
 import com.konkuk.strhat.domain.usecase.PatchStressReliefInfoUseCase
 import com.konkuk.strhat.domain.usecase.SignUpUseCase
 import dagger.Module
@@ -53,4 +54,11 @@ object UseCaseModule {
     fun providesPatchStressReliefInfoUseCase(
         userRepository: UserRepository
     ): PatchStressReliefInfoUseCase = PatchStressReliefInfoUseCase(userRepository)
+
+    @Provides
+    @Singleton
+    fun providesPatchPersonalityInfoUseCase(
+        userRepository: UserRepository
+    ): PatchPersonalityInfoUseCase = PatchPersonalityInfoUseCase(userRepository)
+
 }

--- a/app/src/main/java/com/konkuk/strhat/data/di/UseCaseModule.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/di/UseCaseModule.kt
@@ -7,6 +7,7 @@ import com.konkuk.strhat.domain.usecase.GetUserInfoUseCase
 import com.konkuk.strhat.domain.usecase.HomeUseCase
 import com.konkuk.strhat.domain.usecase.KakaoLoginUseCase
 import com.konkuk.strhat.domain.usecase.PatchHobbyHealingInfoUseCase
+import com.konkuk.strhat.domain.usecase.PatchStressReliefInfoUseCase
 import com.konkuk.strhat.domain.usecase.SignUpUseCase
 import dagger.Module
 import dagger.Provides
@@ -46,4 +47,10 @@ object UseCaseModule {
     fun providesPatchHobbyHealingInfoUseCase(
         userRepository: UserRepository
     ): PatchHobbyHealingInfoUseCase = PatchHobbyHealingInfoUseCase(userRepository)
+
+    @Provides
+    @Singleton
+    fun providesPatchStressReliefInfoUseCase(
+        userRepository: UserRepository
+    ): PatchStressReliefInfoUseCase = PatchStressReliefInfoUseCase(userRepository)
 }

--- a/app/src/main/java/com/konkuk/strhat/data/di/UseCaseModule.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/di/UseCaseModule.kt
@@ -6,6 +6,7 @@ import com.konkuk.strhat.domain.repository.UserRepository
 import com.konkuk.strhat.domain.usecase.GetUserInfoUseCase
 import com.konkuk.strhat.domain.usecase.HomeUseCase
 import com.konkuk.strhat.domain.usecase.KakaoLoginUseCase
+import com.konkuk.strhat.domain.usecase.PatchHobbyHealingInfoUseCase
 import com.konkuk.strhat.domain.usecase.SignUpUseCase
 import dagger.Module
 import dagger.Provides
@@ -39,4 +40,10 @@ object UseCaseModule {
     fun providesGetUserInfoUseCase(
         userRepository: UserRepository
     ): GetUserInfoUseCase = GetUserInfoUseCase(userRepository)
+
+    @Provides
+    @Singleton
+    fun providesPatchHobbyHealingInfoUseCase(
+        userRepository: UserRepository
+    ): PatchHobbyHealingInfoUseCase = PatchHobbyHealingInfoUseCase(userRepository)
 }

--- a/app/src/main/java/com/konkuk/strhat/data/dto/request/RequestHobbyHealingDto.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/dto/request/RequestHobbyHealingDto.kt
@@ -1,0 +1,10 @@
+package com.konkuk.strhat.data.dto.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RequestHobbyHealingDto(
+    @SerialName("hobbyHealingStyle")
+    val hobbyHealingStyle: String
+)

--- a/app/src/main/java/com/konkuk/strhat/data/dto/request/RequestKakaoLoginDto.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/dto/request/RequestKakaoLoginDto.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class RequestkakaoLoginDto(
+data class RequestKakaoLoginDto(
     @SerialName("kakaoAccessToken")
     val kakaoAccessToken: String
 )

--- a/app/src/main/java/com/konkuk/strhat/data/dto/request/RequestPersonalityDto.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/dto/request/RequestPersonalityDto.kt
@@ -1,0 +1,10 @@
+package com.konkuk.strhat.data.dto.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RequestPersonalityDto(
+    @SerialName("personality")
+    val personality: String
+)

--- a/app/src/main/java/com/konkuk/strhat/data/dto/request/RequestReissueTokenDto.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/dto/request/RequestReissueTokenDto.kt
@@ -1,0 +1,10 @@
+package com.konkuk.strhat.data.dto.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RequestReissueTokenDto(
+    @SerialName("refreshToken")
+    val refreshToken: String
+)

--- a/app/src/main/java/com/konkuk/strhat/data/dto/request/RequestStressReliefDto.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/dto/request/RequestStressReliefDto.kt
@@ -1,0 +1,10 @@
+package com.konkuk.strhat.data.dto.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RequestStressReliefDto(
+    @SerialName("stressReliefStyle")
+    val stressReliefStyle: String
+)

--- a/app/src/main/java/com/konkuk/strhat/data/dto/request/RequestUserInfoDto.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/dto/request/RequestUserInfoDto.kt
@@ -1,0 +1,16 @@
+package com.konkuk.strhat.data.dto.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RequestUserInfoDto(
+    @SerialName("nickname")
+    val nickname: String,
+    @SerialName("birth")
+    val birth: Int,
+    @SerialName("gender")
+    val gender: String,
+    @SerialName("job")
+    val job: String
+)

--- a/app/src/main/java/com/konkuk/strhat/data/dto/response/ResponseUserInfoDto.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/dto/response/ResponseUserInfoDto.kt
@@ -1,0 +1,22 @@
+package com.konkuk.strhat.data.dto.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ResponseUserInfoDto(
+    @SerialName("nickname")
+    val nickname: String,
+    @SerialName("birth")
+    val birth: Int,
+    @SerialName("gender")
+    val gender: String,
+    @SerialName("job")
+    val job: String,
+    @SerialName("hobbyHealingStyle")
+    val hobbyHealingStyle: String,
+    @SerialName("stressReliefStyle")
+    val stressReliefStyle: String,
+    @SerialName("personality")
+    val personality: String
+)

--- a/app/src/main/java/com/konkuk/strhat/data/mapper/KakaoAccessTokenMapper.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/mapper/KakaoAccessTokenMapper.kt
@@ -1,8 +1,8 @@
 package com.konkuk.strhat.data.mapper
 
-import com.konkuk.strhat.data.dto.request.RequestkakaoLoginDto
+import com.konkuk.strhat.data.dto.request.RequestKakaoLoginDto
 import com.konkuk.strhat.domain.entity.KakaoAccessTokenModel
 
-fun KakaoAccessTokenModel.toRequestkakaoLoginDto() = RequestkakaoLoginDto(
+fun KakaoAccessTokenModel.toRequestkakaoLoginDto() = RequestKakaoLoginDto(
     kakaoAccessToken = this.accessToken
 )

--- a/app/src/main/java/com/konkuk/strhat/data/mapper/RequestUserInfoMapper.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/mapper/RequestUserInfoMapper.kt
@@ -1,0 +1,17 @@
+package com.konkuk.strhat.data.mapper
+
+import com.konkuk.strhat.data.dto.request.RequestUserInfoDto
+
+fun toRequestUserInfoDto(
+    nickname: String,
+    birth: Int,
+    gender: String,
+    job: String
+): RequestUserInfoDto {
+    return RequestUserInfoDto(
+        nickname = nickname,
+        birth = birth,
+        gender = gender,
+        job = job
+    )
+}

--- a/app/src/main/java/com/konkuk/strhat/data/mapper/UserInfoMapper.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/mapper/UserInfoMapper.kt
@@ -1,0 +1,20 @@
+package com.konkuk.strhat.data.mapper
+
+import com.konkuk.strhat.data.dto.response.ResponseUserInfoDto
+import com.konkuk.strhat.domain.entity.UserInfoModel
+import java.util.Calendar
+
+fun ResponseUserInfoDto.toUserInfoModel(): UserInfoModel {
+    val currentYear = Calendar.getInstance().get(Calendar.YEAR)
+    val age = currentYear - this.birth + 1
+
+    return UserInfoModel(
+        nickname = this.nickname,
+        birth = age,
+        gender = this.gender,
+        job = this.job,
+        hobby = this.hobbyHealingStyle,
+        stress = this.stressReliefStyle,
+        personality = this.personality
+    )
+}

--- a/app/src/main/java/com/konkuk/strhat/data/mapper/UserInfoMapper.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/mapper/UserInfoMapper.kt
@@ -2,15 +2,11 @@ package com.konkuk.strhat.data.mapper
 
 import com.konkuk.strhat.data.dto.response.ResponseUserInfoDto
 import com.konkuk.strhat.domain.entity.UserInfoModel
-import java.util.Calendar
 
 fun ResponseUserInfoDto.toUserInfoModel(): UserInfoModel {
-    val currentYear = Calendar.getInstance().get(Calendar.YEAR)
-    val age = currentYear - this.birth + 1
-
     return UserInfoModel(
         nickname = this.nickname,
-        birth = age,
+        birth = this.birth,
         gender = this.gender,
         job = this.job,
         hobby = this.hobbyHealingStyle,

--- a/app/src/main/java/com/konkuk/strhat/data/repositoryimpl/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/repositoryimpl/AuthRepositoryImpl.kt
@@ -52,4 +52,12 @@ class AuthRepositoryImpl @Inject constructor(
                 refreshToken = refreshToken
             )
         }
+
+    override suspend fun postSignOut(): Result<Unit> =
+        runCatching {
+            val response = authDataSource.postSignOut()
+            if (!response.isSuccessful) {
+                throw Exception("로그아웃 실패: ${response.code()}")
+            }
+        }
 }

--- a/app/src/main/java/com/konkuk/strhat/data/repositoryimpl/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/repositoryimpl/UserRepositoryImpl.kt
@@ -1,0 +1,17 @@
+package com.konkuk.strhat.data.repositoryimpl
+
+import com.konkuk.strhat.data.datasource.UserDataSource
+import com.konkuk.strhat.data.mapper.toUserInfoModel
+import com.konkuk.strhat.domain.entity.UserInfoModel
+import com.konkuk.strhat.domain.repository.UserRepository
+import javax.inject.Inject
+
+class UserRepositoryImpl @Inject constructor(
+    private val userDataSource: UserDataSource
+) : UserRepository {
+    override suspend fun getUserInfo(): Result<UserInfoModel> =
+        runCatching {
+            val response = userDataSource.getUserInfo()
+            response.response.toUserInfoModel()
+        }
+}

--- a/app/src/main/java/com/konkuk/strhat/data/repositoryimpl/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/repositoryimpl/UserRepositoryImpl.kt
@@ -19,4 +19,10 @@ class UserRepositoryImpl @Inject constructor(
         runCatching {
             userDataSource.patchHobbyHealingInfo(hobbyHealingStyle)
         }
+
+    override suspend fun patchStressReliefInfo(stressReliefStyle: String): Result<Unit> =
+        runCatching {
+            userDataSource.patchStressReliefInfo(stressReliefStyle)
+        }
+
 }

--- a/app/src/main/java/com/konkuk/strhat/data/repositoryimpl/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/repositoryimpl/UserRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.konkuk.strhat.data.repositoryimpl
 
 import com.konkuk.strhat.data.datasource.UserDataSource
+import com.konkuk.strhat.data.mapper.toRequestUserInfoDto
 import com.konkuk.strhat.data.mapper.toUserInfoModel
 import com.konkuk.strhat.domain.entity.UserInfoModel
 import com.konkuk.strhat.domain.repository.UserRepository
@@ -13,6 +14,21 @@ class UserRepositoryImpl @Inject constructor(
         runCatching {
             val response = userDataSource.getUserInfo()
             response.response.toUserInfoModel()
+        }
+
+    override suspend fun patchUserInfo(
+        nickname: String,
+        birth: Int,
+        gender: String,
+        job: String
+    ): Result<Unit> =
+        runCatching {
+            val dto = toRequestUserInfoDto(nickname, birth, gender, job)
+            userDataSource.patchUserInfo(dto)
+        }.mapCatching {
+            if (!it.isSuccessful) {
+                throw Exception("유저 정보 수정 실패: ${it.code()}")
+            }
         }
 
     override suspend fun patchHobbyHealingInfo(hobbyHealingStyle: String): Result<Unit> =

--- a/app/src/main/java/com/konkuk/strhat/data/repositoryimpl/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/repositoryimpl/UserRepositoryImpl.kt
@@ -14,4 +14,9 @@ class UserRepositoryImpl @Inject constructor(
             val response = userDataSource.getUserInfo()
             response.response.toUserInfoModel()
         }
+
+    override suspend fun patchHobbyHealingInfo(hobbyHealingStyle: String): Result<Unit> =
+        runCatching {
+            userDataSource.patchHobbyHealingInfo(hobbyHealingStyle)
+        }
 }

--- a/app/src/main/java/com/konkuk/strhat/data/repositoryimpl/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/repositoryimpl/UserRepositoryImpl.kt
@@ -25,4 +25,9 @@ class UserRepositoryImpl @Inject constructor(
             userDataSource.patchStressReliefInfo(stressReliefStyle)
         }
 
+    override suspend fun patchPersonalityInfo(personality: String): Result<Unit> =
+        runCatching {
+            userDataSource.patchPersonalityInfo(personality)
+        }
+
 }

--- a/app/src/main/java/com/konkuk/strhat/data/service/AuthService.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/service/AuthService.kt
@@ -18,4 +18,7 @@ interface AuthService {
     suspend fun signUp(
         @Body signUpRequest: RequestSignUpDto
     ): Response<Unit>
+
+    @POST("/api/v1/users/sign-out")
+    suspend fun signOut(): Response<Unit>
 }

--- a/app/src/main/java/com/konkuk/strhat/data/service/AuthService.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/service/AuthService.kt
@@ -2,7 +2,7 @@ package com.konkuk.strhat.data.service
 
 import com.konkuk.strhat.data.dto.base.BaseResponse
 import com.konkuk.strhat.data.dto.request.RequestSignUpDto
-import com.konkuk.strhat.data.dto.request.RequestkakaoLoginDto
+import com.konkuk.strhat.data.dto.request.RequestKakaoLoginDto
 import com.konkuk.strhat.data.dto.response.ResponseKakaoLoginDto
 import retrofit2.Response
 import retrofit2.http.Body
@@ -11,7 +11,7 @@ import retrofit2.http.POST
 interface AuthService {
     @POST("/api/v1/auth/kakao")
     suspend fun kakaoLogin(
-        @Body kakaoLoginRequest: RequestkakaoLoginDto
+        @Body kakaoLoginRequest: RequestKakaoLoginDto
     ): Response<BaseResponse<ResponseKakaoLoginDto>>
 
     @POST("/api/v1/users/sign-up")

--- a/app/src/main/java/com/konkuk/strhat/data/service/ReIssueService.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/service/ReIssueService.kt
@@ -1,0 +1,13 @@
+package com.konkuk.strhat.data.service
+
+import com.konkuk.strhat.data.dto.request.RequestReissueTokenDto
+import retrofit2.Call
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface ReIssueService {
+    @POST("/api/v1/users/reissue-token")
+    fun reissueToken(
+        @Body reissueTokenRequest: RequestReissueTokenDto
+    ): Call<Unit>
+}

--- a/app/src/main/java/com/konkuk/strhat/data/service/UserService.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/service/UserService.kt
@@ -1,0 +1,10 @@
+package com.konkuk.strhat.data.service
+
+import com.konkuk.strhat.data.dto.base.BaseResponse
+import com.konkuk.strhat.data.dto.response.ResponseUserInfoDto
+import retrofit2.http.GET
+
+interface UserService {
+    @GET("/api/v1/users")
+    suspend fun getUserInfo(): BaseResponse<ResponseUserInfoDto>
+}

--- a/app/src/main/java/com/konkuk/strhat/data/service/UserService.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/service/UserService.kt
@@ -2,6 +2,7 @@ package com.konkuk.strhat.data.service
 
 import com.konkuk.strhat.data.dto.base.BaseResponse
 import com.konkuk.strhat.data.dto.request.RequestHobbyHealingDto
+import com.konkuk.strhat.data.dto.request.RequestStressReliefDto
 import com.konkuk.strhat.data.dto.response.ResponseUserInfoDto
 import retrofit2.Response
 import retrofit2.http.Body
@@ -15,5 +16,10 @@ interface UserService {
     @PATCH("/api/v1/users/hobby-healing-style")
     suspend fun patchHobbyHealingInfo(
         @Body requestHobbyHealingDto: RequestHobbyHealingDto
+    ): Response<Unit>
+
+    @PATCH("api/v1/users/stress-relief-style")
+    suspend fun patchStressReliefInfo(
+        @Body requestStressReliefDto: RequestStressReliefDto
     ): Response<Unit>
 }

--- a/app/src/main/java/com/konkuk/strhat/data/service/UserService.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/service/UserService.kt
@@ -4,6 +4,7 @@ import com.konkuk.strhat.data.dto.base.BaseResponse
 import com.konkuk.strhat.data.dto.request.RequestHobbyHealingDto
 import com.konkuk.strhat.data.dto.request.RequestPersonalityDto
 import com.konkuk.strhat.data.dto.request.RequestStressReliefDto
+import com.konkuk.strhat.data.dto.request.RequestUserInfoDto
 import com.konkuk.strhat.data.dto.response.ResponseUserInfoDto
 import retrofit2.Response
 import retrofit2.http.Body
@@ -29,4 +30,8 @@ interface UserService {
         @Body requestPersonalityDto: RequestPersonalityDto
     ): Response<Unit>
 
+    @PATCH("/api/v1/users/info")
+    suspend fun patchUserInfo(
+        @Body requestUserInfoDto: RequestUserInfoDto
+    ): Response<Unit>
 }

--- a/app/src/main/java/com/konkuk/strhat/data/service/UserService.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/service/UserService.kt
@@ -1,10 +1,19 @@
 package com.konkuk.strhat.data.service
 
 import com.konkuk.strhat.data.dto.base.BaseResponse
+import com.konkuk.strhat.data.dto.request.RequestHobbyHealingDto
 import com.konkuk.strhat.data.dto.response.ResponseUserInfoDto
+import retrofit2.Response
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.PATCH
 
 interface UserService {
     @GET("/api/v1/users")
     suspend fun getUserInfo(): BaseResponse<ResponseUserInfoDto>
+
+    @PATCH("/api/v1/users/hobby-healing-style")
+    suspend fun patchHobbyHealingInfo(
+        @Body requestHobbyHealingDto: RequestHobbyHealingDto
+    ): Response<Unit>
 }

--- a/app/src/main/java/com/konkuk/strhat/data/service/UserService.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/service/UserService.kt
@@ -2,6 +2,7 @@ package com.konkuk.strhat.data.service
 
 import com.konkuk.strhat.data.dto.base.BaseResponse
 import com.konkuk.strhat.data.dto.request.RequestHobbyHealingDto
+import com.konkuk.strhat.data.dto.request.RequestPersonalityDto
 import com.konkuk.strhat.data.dto.request.RequestStressReliefDto
 import com.konkuk.strhat.data.dto.response.ResponseUserInfoDto
 import retrofit2.Response
@@ -18,8 +19,14 @@ interface UserService {
         @Body requestHobbyHealingDto: RequestHobbyHealingDto
     ): Response<Unit>
 
-    @PATCH("api/v1/users/stress-relief-style")
+    @PATCH("/api/v1/users/stress-relief-style")
     suspend fun patchStressReliefInfo(
         @Body requestStressReliefDto: RequestStressReliefDto
     ): Response<Unit>
+
+    @PATCH("/api/v1/users/personality")
+    suspend fun patchPersonalityInfo(
+        @Body requestPersonalityDto: RequestPersonalityDto
+    ): Response<Unit>
+
 }

--- a/app/src/main/java/com/konkuk/strhat/domain/entity/UserInfoModel.kt
+++ b/app/src/main/java/com/konkuk/strhat/domain/entity/UserInfoModel.kt
@@ -1,0 +1,11 @@
+package com.konkuk.strhat.domain.entity
+
+data class UserInfoModel(
+    val nickname: String,
+    val birth: Int,
+    val gender: String,
+    val job: String,
+    val hobby: String,
+    val stress: String,
+    val personality: String
+)

--- a/app/src/main/java/com/konkuk/strhat/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/com/konkuk/strhat/domain/repository/AuthRepository.kt
@@ -8,4 +8,5 @@ import com.konkuk.strhat.domain.entity.TokenModel
 interface AuthRepository {
     suspend fun postKakaoLogin(kakaoAccessToken: KakaoAccessTokenModel): Result<KakaoLoginModel>
     suspend fun postSignUp(signUpRequest: SignUpModel): Result<TokenModel>
+    suspend fun postSignOut(): Result<Unit>
 }

--- a/app/src/main/java/com/konkuk/strhat/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/konkuk/strhat/domain/repository/UserRepository.kt
@@ -4,4 +4,5 @@ import com.konkuk.strhat.domain.entity.UserInfoModel
 
 interface UserRepository {
     suspend fun getUserInfo(): Result<UserInfoModel>
+    suspend fun patchHobbyHealingInfo(hobbyHealingStyle: String): Result<Unit>
 }

--- a/app/src/main/java/com/konkuk/strhat/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/konkuk/strhat/domain/repository/UserRepository.kt
@@ -6,4 +6,6 @@ interface UserRepository {
     suspend fun getUserInfo(): Result<UserInfoModel>
     suspend fun patchHobbyHealingInfo(hobbyHealingStyle: String): Result<Unit>
     suspend fun patchStressReliefInfo(stressReliefStyle: String): Result<Unit>
+    suspend fun patchPersonalityInfo(personality: String): Result<Unit>
+
 }

--- a/app/src/main/java/com/konkuk/strhat/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/konkuk/strhat/domain/repository/UserRepository.kt
@@ -1,0 +1,7 @@
+package com.konkuk.strhat.domain.repository
+
+import com.konkuk.strhat.domain.entity.UserInfoModel
+
+interface UserRepository {
+    suspend fun getUserInfo(): Result<UserInfoModel>
+}

--- a/app/src/main/java/com/konkuk/strhat/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/konkuk/strhat/domain/repository/UserRepository.kt
@@ -4,8 +4,8 @@ import com.konkuk.strhat.domain.entity.UserInfoModel
 
 interface UserRepository {
     suspend fun getUserInfo(): Result<UserInfoModel>
+    suspend fun patchUserInfo(nickname: String, birth: Int, gender: String, job: String): Result<Unit>
     suspend fun patchHobbyHealingInfo(hobbyHealingStyle: String): Result<Unit>
     suspend fun patchStressReliefInfo(stressReliefStyle: String): Result<Unit>
     suspend fun patchPersonalityInfo(personality: String): Result<Unit>
-
 }

--- a/app/src/main/java/com/konkuk/strhat/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/konkuk/strhat/domain/repository/UserRepository.kt
@@ -5,4 +5,5 @@ import com.konkuk.strhat.domain.entity.UserInfoModel
 interface UserRepository {
     suspend fun getUserInfo(): Result<UserInfoModel>
     suspend fun patchHobbyHealingInfo(hobbyHealingStyle: String): Result<Unit>
+    suspend fun patchStressReliefInfo(stressReliefStyle: String): Result<Unit>
 }

--- a/app/src/main/java/com/konkuk/strhat/domain/usecase/GetUserInfoUseCase.kt
+++ b/app/src/main/java/com/konkuk/strhat/domain/usecase/GetUserInfoUseCase.kt
@@ -1,0 +1,11 @@
+package com.konkuk.strhat.domain.usecase
+
+import com.konkuk.strhat.domain.entity.UserInfoModel
+import com.konkuk.strhat.domain.repository.UserRepository
+import javax.inject.Inject
+
+class GetUserInfoUseCase @Inject constructor(
+    private val userRepository: UserRepository
+){
+    suspend operator fun invoke(): Result<UserInfoModel> = userRepository.getUserInfo()
+}

--- a/app/src/main/java/com/konkuk/strhat/domain/usecase/PatchHobbyHealingInfoUseCase.kt
+++ b/app/src/main/java/com/konkuk/strhat/domain/usecase/PatchHobbyHealingInfoUseCase.kt
@@ -1,0 +1,10 @@
+package com.konkuk.strhat.domain.usecase
+
+import com.konkuk.strhat.domain.repository.UserRepository
+import javax.inject.Inject
+
+class PatchHobbyHealingInfoUseCase @Inject constructor(
+    private val userRepository: UserRepository
+){
+    suspend operator fun invoke(hobbyHealing: String) = userRepository.patchHobbyHealingInfo(hobbyHealing)
+}

--- a/app/src/main/java/com/konkuk/strhat/domain/usecase/PatchPersonalityInfoUseCase.kt
+++ b/app/src/main/java/com/konkuk/strhat/domain/usecase/PatchPersonalityInfoUseCase.kt
@@ -1,0 +1,10 @@
+package com.konkuk.strhat.domain.usecase
+
+import com.konkuk.strhat.domain.repository.UserRepository
+import javax.inject.Inject
+
+class PatchPersonalityInfoUseCase @Inject constructor(
+    private val userRepository: UserRepository
+){
+    suspend operator fun invoke(personality: String) = userRepository.patchPersonalityInfo(personality)
+}

--- a/app/src/main/java/com/konkuk/strhat/domain/usecase/PatchStressReliefInfoUseCase.kt
+++ b/app/src/main/java/com/konkuk/strhat/domain/usecase/PatchStressReliefInfoUseCase.kt
@@ -1,0 +1,10 @@
+package com.konkuk.strhat.domain.usecase
+
+import com.konkuk.strhat.domain.repository.UserRepository
+import javax.inject.Inject
+
+class PatchStressReliefInfoUseCase @Inject constructor(
+    private val userRepository: UserRepository
+){
+    suspend operator fun invoke(stressRelief: String) = userRepository.patchStressReliefInfo(stressRelief)
+}

--- a/app/src/main/java/com/konkuk/strhat/domain/usecase/PatchUserInfoUseCase.kt
+++ b/app/src/main/java/com/konkuk/strhat/domain/usecase/PatchUserInfoUseCase.kt
@@ -1,0 +1,20 @@
+package com.konkuk.strhat.domain.usecase
+
+import com.konkuk.strhat.domain.repository.UserRepository
+import javax.inject.Inject
+
+class PatchUserInfoUseCase @Inject constructor(
+    private val userRepository: UserRepository
+) {
+    suspend operator fun invoke(
+        nickname: String,
+        birth: Int,
+        gender: String,
+        job: String
+    ) = userRepository.patchUserInfo(
+        nickname = nickname,
+        birth = birth,
+        gender = gender,
+        job = job
+    )
+}

--- a/app/src/main/java/com/konkuk/strhat/domain/usecase/SignOutUseCase.kt
+++ b/app/src/main/java/com/konkuk/strhat/domain/usecase/SignOutUseCase.kt
@@ -1,0 +1,11 @@
+package com.konkuk.strhat.domain.usecase
+
+import com.konkuk.strhat.domain.repository.AuthRepository
+import javax.inject.Inject
+
+class SignOutUseCase @Inject constructor(
+    private val authRepository: AuthRepository
+){
+    suspend operator fun invoke(): Result<Unit> =
+        authRepository.postSignOut()
+}

--- a/app/src/main/java/com/konkuk/strhat/feature/login/LoginScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/login/LoginScreen.kt
@@ -34,6 +34,7 @@ import com.konkuk.strhat.ui.theme.StrHatTheme.typography
 fun LoginRoute(
     padding: PaddingValues,
     navigateToOnBoarding: () -> Unit,
+    navigateToHome: () -> Unit,
     viewModel: LoginViewModel = hiltViewModel()
 ) {
     val context = LocalContext.current
@@ -42,7 +43,7 @@ fun LoginRoute(
     LaunchedEffect(loginResult.value) {
         if (loginResult.value?.isSuccess == true) {
             if (loginResult.value?.isExistingUser == true) {
-                // TODO: navigateToHome()
+                navigateToHome()
             } else {
                 navigateToOnBoarding()
             }

--- a/app/src/main/java/com/konkuk/strhat/feature/login/navigation/LoginNavigation.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/login/navigation/LoginNavigation.kt
@@ -14,12 +14,14 @@ fun NavController.navigateToLogin(navOptions: NavOptions) {
 
 fun NavGraphBuilder.loginNavGraph(
     padding: PaddingValues,
-    onNavigateToOnBoarding: () -> Unit
+    onNavigateToOnBoarding: () -> Unit,
+    onNavigateToHome: () -> Unit
 ) {
     composable<Login> {
         LoginRoute(
             padding = padding,
-            navigateToOnBoarding = onNavigateToOnBoarding
+            navigateToOnBoarding = onNavigateToOnBoarding,
+            navigateToHome = onNavigateToHome
         )
     }
 }

--- a/app/src/main/java/com/konkuk/strhat/feature/main/MainActivity.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/main/MainActivity.kt
@@ -5,15 +5,25 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import com.konkuk.strhat.core.network.TokenManager
+import com.konkuk.strhat.core.util.AppRestartUtil
 import com.konkuk.strhat.ui.theme.StrHatTheme
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+    @Inject lateinit var tokenManager: TokenManager
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
         enableEdgeToEdge()
+
+        tokenManager.setLogoutCallback {
+            tokenManager.clear()
+            AppRestartUtil.restartApp(applicationContext)
+        }
+
         setContent {
             val navigator: MainNavigator = rememberMainNavigator()
             StrHatTheme {

--- a/app/src/main/java/com/konkuk/strhat/feature/main/component/MainNavHost.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/main/component/MainNavHost.kt
@@ -75,7 +75,6 @@ fun MainNavHost(
             myPageNavGraph(
                 padding = padding,
                 onNavigateToMyPage = navigator::navigateToMyPage,
-                onNavigateToLogin = navigator::navigateToLogin,
                 onNavigateToMySelfDiagnosisRecord = navigator::navigateToMySelfDiagnosisRecord,
                 onNavigateToMySelfDiagnosisRecordResult = navigator::navigateToMySelfDiagnosisRecordResult,
                 onNavigateToTodayStressScore = navigator::navigateToTodayStressScore,

--- a/app/src/main/java/com/konkuk/strhat/feature/main/component/MainNavHost.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/main/component/MainNavHost.kt
@@ -93,7 +93,8 @@ fun MainNavHost(
 
             loginNavGraph(
                 padding = padding,
-                onNavigateToOnBoarding = navigator::navigateToOnBoarding
+                onNavigateToOnBoarding = navigator::navigateToOnBoarding,
+                onNavigateToHome = navigator::navigateToHome
             )
 
             onBoardingNavGraph(

--- a/app/src/main/java/com/konkuk/strhat/feature/mypage/MyAccountScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/mypage/MyAccountScreen.kt
@@ -153,8 +153,8 @@ private fun PreviewMyAccountScreen() {
             myPageModel = MyPageModel(
                 nickname = "송밍서",
                 birth = 2001,
-                gender = "MALE",
-                job = "STUDENT",
+                gender = "",
+                job = "",
                 hobbyHealingStyle = "1. 혼자만의 시간을 보내며 독서를 좋아함. ...",
                 stressReliefStyle = "1. 집 앞 공원에 나가 찬 공기를 ...",
                 personality = "1. 내성적인 편임 ..."

--- a/app/src/main/java/com/konkuk/strhat/feature/mypage/MyAccountScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/mypage/MyAccountScreen.kt
@@ -51,7 +51,11 @@ fun MyAccountRoute(
         onOptionSelected = viewModel::updateGender,
         selectedJob = myPageModel.job,
         onJobSelected = viewModel::updateJob,
-        navigateToMyPage = navigateToMyPage
+        navigateToMyPage = {
+            viewModel.patchUserInfo {
+                navigateToMyPage()
+            }
+        }
     )
 }
 

--- a/app/src/main/java/com/konkuk/strhat/feature/mypage/MyHealingScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/mypage/MyHealingScreen.kt
@@ -42,7 +42,11 @@ fun MyHealingRoute(
         padding = padding,
         healing = myPageModel.hobbyHealingStyle,
         onHealingChange = viewModel::updateHealing,
-        navigateToMyPage = navigateToMyPage
+        navigateToMyPage = {
+            viewModel.patchHealingInfo {
+                navigateToMyPage()
+            }
+        }
     )
 }
 

--- a/app/src/main/java/com/konkuk/strhat/feature/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/mypage/MyPageScreen.kt
@@ -40,6 +40,7 @@ import com.konkuk.strhat.core.util.modifier.noRippleClickable
 import com.konkuk.strhat.domain.entity.MyPageModel
 import com.konkuk.strhat.ui.theme.StrHatTheme.colors
 import com.konkuk.strhat.ui.theme.StrHatTheme.typography
+import java.util.Calendar
 
 @Composable
 fun MyPageRoute(
@@ -86,6 +87,8 @@ private fun MyPageScreen(
     myPageModel: MyPageModel
 ) {
     var isLogoutDialogVisible by remember { mutableStateOf(false) }
+    val currentYear = Calendar.getInstance().get(Calendar.YEAR)
+    val age = currentYear - myPageModel.birth + 1
 
     Column(
         modifier = Modifier
@@ -136,7 +139,7 @@ private fun MyPageScreen(
                     )
 
                     Text(
-                        text = myPageModel.birth.toString(),
+                        text = age.toString(),
                         style = typography.head2_r_20,
                         color = colors.Gray400
                     )

--- a/app/src/main/java/com/konkuk/strhat/feature/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/mypage/MyPageScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -224,7 +225,9 @@ private fun MyPageScreen(
             Text(
                 text = myPageModel.hobbyHealingStyle,
                 style = typography.body2_r_15,
-                color = colors.Gray500
+                color = colors.Gray500,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
             )
         }
 
@@ -261,7 +264,9 @@ private fun MyPageScreen(
             Text(
                 text = myPageModel.stressReliefStyle,
                 style = typography.body2_r_15,
-                color = colors.Gray500
+                color = colors.Gray500,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
             )
         }
 
@@ -298,7 +303,9 @@ private fun MyPageScreen(
             Text(
                 text = myPageModel.personality,
                 style = typography.body2_r_15,
-                color = colors.Gray500
+                color = colors.Gray500,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
             )
         }
 
@@ -313,7 +320,8 @@ private fun MyPageScreen(
             text = stringResource(R.string.my_more_graph),
             style = typography.body1_r_16,
             color = colors.MainBlack,
-            modifier = Modifier.padding(bottom = 15.dp)
+            modifier = Modifier
+                .padding(bottom = 15.dp)
                 .noRippleClickable {
                     navigateToChangeGraph()
                 }
@@ -328,7 +336,8 @@ private fun MyPageScreen(
             text = stringResource(R.string.my_more_stress_score),
             style = typography.body1_r_16,
             color = colors.MainBlack,
-            modifier = Modifier.padding(bottom = 15.dp)
+            modifier = Modifier
+                .padding(bottom = 15.dp)
                 .noRippleClickable {
                     navigateToTodayStressScore()
                 }
@@ -343,7 +352,8 @@ private fun MyPageScreen(
             text = stringResource(R.string.my_more_record),
             style = typography.body1_r_16,
             color = colors.MainBlack,
-            modifier = Modifier.padding(bottom = 15.dp)
+            modifier = Modifier
+                .padding(bottom = 15.dp)
                 .noRippleClickable {
                     navigateToMySelfDiagnosisRecord()
                 }

--- a/app/src/main/java/com/konkuk/strhat/feature/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/mypage/MyPageScreen.kt
@@ -47,7 +47,6 @@ fun MyPageRoute(
     navigateToHealing: () -> Unit,
     navigateToStress: () -> Unit,
     navigateToPersonality: () -> Unit,
-    navigateToLogin: () -> Unit,
     navigateToMySelfDiagnosisRecord: () -> Unit,
     navigateToTodayStressScore: () -> Unit,
     navigateToChangeGraph: () -> Unit,
@@ -64,10 +63,10 @@ fun MyPageRoute(
         navigateToHealing = navigateToHealing,
         navigateToStress = navigateToStress,
         navigateToPersonality = navigateToPersonality,
-        navigateToLogin = navigateToLogin,
         navigateToMySelfDiagnosisRecord = navigateToMySelfDiagnosisRecord,
         navigateToTodayStressScore = navigateToTodayStressScore,
         navigateToChangeGraph = navigateToChangeGraph,
+        onSignOutClick = { viewModel.signOut() },
         myPageModel = myPageModel
     )
 }
@@ -79,10 +78,10 @@ private fun MyPageScreen(
     navigateToHealing: () -> Unit,
     navigateToStress: () -> Unit,
     navigateToPersonality: () -> Unit,
-    navigateToLogin: () -> Unit,
     navigateToMySelfDiagnosisRecord: () -> Unit,
     navigateToTodayStressScore: () -> Unit,
     navigateToChangeGraph: () -> Unit,
+    onSignOutClick: () -> Unit,
     myPageModel: MyPageModel
 ) {
     var isLogoutDialogVisible by remember { mutableStateOf(false) }
@@ -379,7 +378,7 @@ private fun MyPageScreen(
                 descriptionResId = R.string.dialog_logout_description,
                 onConfirmButtonClick = {
                     isLogoutDialogVisible = false
-                    navigateToLogin()
+                    onSignOutClick()
                 },
                 onDismissButtonClick = { isLogoutDialogVisible = false }
             )
@@ -401,10 +400,10 @@ private fun PreviewMyPageScreen() {
             navigateToHealing = {},
             navigateToStress = {},
             navigateToPersonality = {},
-            navigateToLogin = {},
             navigateToMySelfDiagnosisRecord = {},
             navigateToTodayStressScore = {},
             navigateToChangeGraph = {},
+            onSignOutClick = {},
             myPageModel = MyPageModel(
                 nickname = "송밍서",
                 birth = 2001,

--- a/app/src/main/java/com/konkuk/strhat/feature/mypage/MyPageViewModel.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/mypage/MyPageViewModel.kt
@@ -8,6 +8,7 @@ import com.konkuk.strhat.domain.usecase.GetUserInfoUseCase
 import com.konkuk.strhat.domain.usecase.PatchHobbyHealingInfoUseCase
 import com.konkuk.strhat.domain.usecase.PatchPersonalityInfoUseCase
 import com.konkuk.strhat.domain.usecase.PatchStressReliefInfoUseCase
+import com.konkuk.strhat.domain.usecase.PatchUserInfoUseCase
 import com.konkuk.strhat.domain.usecase.SignOutUseCase
 import com.konkuk.strhat.feature.mypage.state.MyWeeklyStressState
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -21,6 +22,7 @@ import javax.inject.Inject
 @HiltViewModel
 class MyPageViewModel @Inject constructor(
     private val userInfoUseCase: GetUserInfoUseCase,
+    private val patchUserInfoUseCase: PatchUserInfoUseCase,
     private val patchHobbyHealingInfoUseCase: PatchHobbyHealingInfoUseCase,
     private val patchStressReliefInfoUseCase: PatchStressReliefInfoUseCase,
     private val patchPersonalityInfoUseCase: PatchPersonalityInfoUseCase,
@@ -102,6 +104,22 @@ class MyPageViewModel @Inject constructor(
         _myPageModel.value = _myPageModel.value.copy(personality = personality)
     }
 
+    fun patchUserInfo(onComplete: () -> Unit) {
+        viewModelScope.launch {
+            val user = _myPageModel.value
+            patchUserInfoUseCase(
+                nickname = user.nickname,
+                birth = user.birth,
+                gender = user.gender,
+                job = user.job
+            ).onSuccess {
+                onComplete()
+            }.onFailure {
+                Timber.e("유저 정보 수정 실패: ${it.message}")
+            }
+        }
+    }
+
     fun patchHealingInfo(onComplete: () -> Unit) {
         viewModelScope.launch {
             val healing = _myPageModel.value.hobbyHealingStyle
@@ -143,8 +161,6 @@ class MyPageViewModel @Inject constructor(
 
     fun signOut(){
         viewModelScope.launch {
-            Timber.d("📡 로그아웃 요청 토큰: ${tokenManager.getToken()}")
-
             signOutUseCase()
                 .onSuccess {
                     tokenManager.triggerLogout()

--- a/app/src/main/java/com/konkuk/strhat/feature/mypage/MyPageViewModel.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/mypage/MyPageViewModel.kt
@@ -1,16 +1,24 @@
 package com.konkuk.strhat.feature.mypage
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.konkuk.strhat.core.network.TokenManager
 import com.konkuk.strhat.domain.entity.MyPageModel
+import com.konkuk.strhat.domain.usecase.SignOutUseCase
 import com.konkuk.strhat.feature.mypage.state.MyWeeklyStressState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
-class MyPageViewModel @Inject constructor() : ViewModel() {
+class MyPageViewModel @Inject constructor(
+    private val signOutUseCase: SignOutUseCase,
+    private val tokenManager: TokenManager
+) : ViewModel() {
     private val _myPageModel = MutableStateFlow(
         MyPageModel(
             nickname = "",
@@ -77,5 +85,19 @@ class MyPageViewModel @Inject constructor() : ViewModel() {
 
     fun updatePersonality(personality: String) {
         _myPageModel.value = _myPageModel.value.copy(personality = personality)
+    }
+
+    fun signOut(){
+        viewModelScope.launch {
+            Timber.d("📡 로그아웃 요청 토큰: ${tokenManager.getToken()}")
+
+            signOutUseCase()
+                .onSuccess {
+                    tokenManager.triggerLogout()
+                }
+                .onFailure {
+                    Timber.e("로그아웃 실패: ${it.message}")
+                }
+        }
     }
 }

--- a/app/src/main/java/com/konkuk/strhat/feature/mypage/MyPageViewModel.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/mypage/MyPageViewModel.kt
@@ -6,6 +6,7 @@ import com.konkuk.strhat.core.network.TokenManager
 import com.konkuk.strhat.domain.entity.MyPageModel
 import com.konkuk.strhat.domain.usecase.GetUserInfoUseCase
 import com.konkuk.strhat.domain.usecase.PatchHobbyHealingInfoUseCase
+import com.konkuk.strhat.domain.usecase.PatchPersonalityInfoUseCase
 import com.konkuk.strhat.domain.usecase.PatchStressReliefInfoUseCase
 import com.konkuk.strhat.domain.usecase.SignOutUseCase
 import com.konkuk.strhat.feature.mypage.state.MyWeeklyStressState
@@ -22,6 +23,7 @@ class MyPageViewModel @Inject constructor(
     private val userInfoUseCase: GetUserInfoUseCase,
     private val patchHobbyHealingInfoUseCase: PatchHobbyHealingInfoUseCase,
     private val patchStressReliefInfoUseCase: PatchStressReliefInfoUseCase,
+    private val patchPersonalityInfoUseCase: PatchPersonalityInfoUseCase,
     private val signOutUseCase: SignOutUseCase,
     private val tokenManager: TokenManager
 ) : ViewModel() {
@@ -117,6 +119,19 @@ class MyPageViewModel @Inject constructor(
         viewModelScope.launch {
             val stress = _myPageModel.value.stressReliefStyle
             patchStressReliefInfoUseCase(stress)
+                .onSuccess {
+                    onComplete()
+                }
+                .onFailure {
+                    Timber.e("유저 정보 수정 실패: ${it.message}")
+                }
+        }
+    }
+
+    fun patchPersonalityInfo(onComplete: () -> Unit) {
+        viewModelScope.launch {
+            val personality = _myPageModel.value.personality
+            patchPersonalityInfoUseCase(personality)
                 .onSuccess {
                     onComplete()
                 }

--- a/app/src/main/java/com/konkuk/strhat/feature/mypage/MyPageViewModel.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/mypage/MyPageViewModel.kt
@@ -6,6 +6,7 @@ import com.konkuk.strhat.core.network.TokenManager
 import com.konkuk.strhat.domain.entity.MyPageModel
 import com.konkuk.strhat.domain.usecase.GetUserInfoUseCase
 import com.konkuk.strhat.domain.usecase.PatchHobbyHealingInfoUseCase
+import com.konkuk.strhat.domain.usecase.PatchStressReliefInfoUseCase
 import com.konkuk.strhat.domain.usecase.SignOutUseCase
 import com.konkuk.strhat.feature.mypage.state.MyWeeklyStressState
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -20,6 +21,7 @@ import javax.inject.Inject
 class MyPageViewModel @Inject constructor(
     private val userInfoUseCase: GetUserInfoUseCase,
     private val patchHobbyHealingInfoUseCase: PatchHobbyHealingInfoUseCase,
+    private val patchStressReliefInfoUseCase: PatchStressReliefInfoUseCase,
     private val signOutUseCase: SignOutUseCase,
     private val tokenManager: TokenManager
 ) : ViewModel() {
@@ -102,6 +104,19 @@ class MyPageViewModel @Inject constructor(
         viewModelScope.launch {
             val healing = _myPageModel.value.hobbyHealingStyle
             patchHobbyHealingInfoUseCase(healing)
+                .onSuccess {
+                    onComplete()
+                }
+                .onFailure {
+                    Timber.e("유저 정보 수정 실패: ${it.message}")
+                }
+        }
+    }
+
+    fun patchStressInfo(onComplete: () -> Unit) {
+        viewModelScope.launch {
+            val stress = _myPageModel.value.stressReliefStyle
+            patchStressReliefInfoUseCase(stress)
                 .onSuccess {
                     onComplete()
                 }

--- a/app/src/main/java/com/konkuk/strhat/feature/mypage/MyPageViewModel.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/mypage/MyPageViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.konkuk.strhat.core.network.TokenManager
 import com.konkuk.strhat.domain.entity.MyPageModel
+import com.konkuk.strhat.domain.usecase.GetUserInfoUseCase
 import com.konkuk.strhat.domain.usecase.SignOutUseCase
 import com.konkuk.strhat.feature.mypage.state.MyWeeklyStressState
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -16,6 +17,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class MyPageViewModel @Inject constructor(
+    private val userInfoUseCase: GetUserInfoUseCase,
     private val signOutUseCase: SignOutUseCase,
     private val tokenManager: TokenManager
 ) : ViewModel() {
@@ -47,16 +49,23 @@ class MyPageViewModel @Inject constructor(
     }
 
     fun getMyPageModel() {
-        _myPageModel.value =
-            MyPageModel(
-                nickname = "송밍서",
-                birth = 2001,
-                gender = "여자",
-                job = "STUDENT",
-                hobbyHealingStyle = "1. 혼자만의 시간을 보내며 독서를 좋아함. ...",
-                stressReliefStyle = "1. 집 앞 공원에 나가 찬 공기를 ...",
-                personality = "1. 내성적인 편임 ..."
-            )
+        viewModelScope.launch {
+            userInfoUseCase()
+                .onSuccess { user ->
+                    _myPageModel.value = MyPageModel(
+                        nickname = user.nickname,
+                        birth = user.birth,
+                        gender = user.gender,
+                        job = user.job,
+                        hobbyHealingStyle = user.hobby,
+                        stressReliefStyle = user.stress,
+                        personality = user.personality
+                    )
+                }
+                .onFailure {
+                    Timber.e("유저 정보 조회 실패: ${it.message}")
+                }
+        }
     }
 
     fun updateNickName(nickname: String) {

--- a/app/src/main/java/com/konkuk/strhat/feature/mypage/MyPageViewModel.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/mypage/MyPageViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.konkuk.strhat.core.network.TokenManager
 import com.konkuk.strhat.domain.entity.MyPageModel
 import com.konkuk.strhat.domain.usecase.GetUserInfoUseCase
+import com.konkuk.strhat.domain.usecase.PatchHobbyHealingInfoUseCase
 import com.konkuk.strhat.domain.usecase.SignOutUseCase
 import com.konkuk.strhat.feature.mypage.state.MyWeeklyStressState
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -18,6 +19,7 @@ import javax.inject.Inject
 @HiltViewModel
 class MyPageViewModel @Inject constructor(
     private val userInfoUseCase: GetUserInfoUseCase,
+    private val patchHobbyHealingInfoUseCase: PatchHobbyHealingInfoUseCase,
     private val signOutUseCase: SignOutUseCase,
     private val tokenManager: TokenManager
 ) : ViewModel() {
@@ -94,6 +96,19 @@ class MyPageViewModel @Inject constructor(
 
     fun updatePersonality(personality: String) {
         _myPageModel.value = _myPageModel.value.copy(personality = personality)
+    }
+
+    fun patchHealingInfo(onComplete: () -> Unit) {
+        viewModelScope.launch {
+            val healing = _myPageModel.value.hobbyHealingStyle
+            patchHobbyHealingInfoUseCase(healing)
+                .onSuccess {
+                    onComplete()
+                }
+                .onFailure {
+                    Timber.e("유저 정보 수정 실패: ${it.message}")
+                }
+        }
     }
 
     fun signOut(){

--- a/app/src/main/java/com/konkuk/strhat/feature/mypage/MyPersonalityScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/mypage/MyPersonalityScreen.kt
@@ -41,7 +41,11 @@ fun MyPersonalityRoute(
         padding = padding,
         personality = myPageModel.personality,
         onPersonalityChange = viewModel::updatePersonality,
-        navigateToMyPage = navigateToMyPage
+        navigateToMyPage = {
+            viewModel.patchPersonalityInfo {
+                navigateToMyPage()
+            }
+        }
     )
 }
 

--- a/app/src/main/java/com/konkuk/strhat/feature/mypage/MyStressScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/mypage/MyStressScreen.kt
@@ -41,7 +41,11 @@ fun MyStressRoute(
         padding = padding,
         stress = myPageModel.stressReliefStyle,
         onStressChange = viewModel::updateStress,
-        navigateToMyPage = navigateToMyPage
+        navigateToMyPage = {
+            viewModel.patchStressInfo {
+                navigateToMyPage()
+            }
+        }
     )
 }
 

--- a/app/src/main/java/com/konkuk/strhat/feature/mypage/navigation/MyPageNavigation.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/mypage/navigation/MyPageNavigation.kt
@@ -62,7 +62,6 @@ fun NavController.navigateToMyPageChatHistory() {
 fun NavGraphBuilder.myPageNavGraph(
     padding: PaddingValues,
     onNavigateToMyPage: () -> Unit,
-    onNavigateToLogin: () -> Unit,
     onNavigateToMySelfDiagnosisRecord: () -> Unit,
     onNavigateToMySelfDiagnosisRecordResult: () -> Unit,
     onNavigateToTodayStressScore: () -> Unit,
@@ -80,7 +79,6 @@ fun NavGraphBuilder.myPageNavGraph(
             navigateToStress = navController::navigateToStress,
             navigateToPersonality = navController::navigateToPersonality,
             navigateToMySelfDiagnosisRecord = onNavigateToMySelfDiagnosisRecord,
-            navigateToLogin = onNavigateToLogin,
             navigateToTodayStressScore = onNavigateToTodayStressScore,
             navigateToChangeGraph = onNavigateToChangeGraph
         )


### PR DESCRIPTION
## Related issue 🛠
- closed #28 
- closed #30 

## Work Description 📝
### 토큰 관련 API
- [x] 카카오 로그인(소셜 로그인) 환경 세팅
- [x] 회원가입 API 연동
- [x] 카카오 토큰 검증 및 로그인 API 연동
- [x] AccessToken 재발급 API 연동
- [x] 로그아웃 API 연동

### 마이페이지 API
- [x] 계정 정보 조회
- [x] 계정 정보 수정
- [x] 취미 및 힐링 방법 수정
- [x] 스트레스 해소 방법 수정
- [x] 성향 정보 수정

## Screenshot 📸
회원가입 - 마이페이지 플로우

https://github.com/user-attachments/assets/12f671cf-cd80-4609-8c08-d64d825d6098

소셜 로그인 - 로그아웃 플로우

https://github.com/user-attachments/assets/af0a3136-389c-461d-946f-e667bb93e944

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
두 가지 이슈를 담은 .. 미친 고봉밥 pr ...
일단 토큰 관리 부분에 있어서 부족한게 많을 것 같습니다. 추후 리팩 예정 !
+) 로그아웃, 리프레시 토큰 만료 처리를 새롭게 안드로이드 공식 문서에서 추천하는대로 앱 재시작 로직으로 구현해보았습니다.