### PR TITLE
[FEAT/#33] 자가진단, 스트레스 변화 시각화 서버통신 구현

### DIFF
--- a/app/src/main/java/com/konkuk/strhat/core/navigation/RouteModel.kt
+++ b/app/src/main/java/com/konkuk/strhat/core/navigation/RouteModel.kt
@@ -52,7 +52,9 @@ sealed interface MyPageRoute: Route{
     @Serializable
     data object MySelfDiagnosisRecordResult: MyPageRoute
     @Serializable
-    data object MyStressEmotionChangeGraph: MyPageRoute
+    data class MyStressEmotionChangeGraph(
+        val date: String
+    ): MyPageRoute
     @Serializable
     data object MyPageStressScore: MyPageRoute
     @Serializable

--- a/app/src/main/java/com/konkuk/strhat/core/navigation/RouteModel.kt
+++ b/app/src/main/java/com/konkuk/strhat/core/navigation/RouteModel.kt
@@ -56,7 +56,9 @@ sealed interface MyPageRoute: Route{
         val date: String
     ): MyPageRoute
     @Serializable
-    data object MyPageStressScore: MyPageRoute
+    data class MyPageStressScore(
+        val date: String
+    ): MyPageRoute
     @Serializable
     data class MyPageChatHistory(
         val diaryId: Int

--- a/app/src/main/java/com/konkuk/strhat/core/navigation/RouteModel.kt
+++ b/app/src/main/java/com/konkuk/strhat/core/navigation/RouteModel.kt
@@ -91,7 +91,9 @@ sealed interface DiaryRoute : Route {
 
 sealed interface SelfDiagnosisRoute : Route {
     @Serializable
-    data object SelfDiagnosisTest : Route
+    data class SelfDiagnosisTest(
+        val type: String
+    ) : Route
     @Serializable
     data object SelfDiagnosisResult : Route
 }

--- a/app/src/main/java/com/konkuk/strhat/core/navigation/RouteModel.kt
+++ b/app/src/main/java/com/konkuk/strhat/core/navigation/RouteModel.kt
@@ -99,5 +99,7 @@ sealed interface SelfDiagnosisRoute : Route {
         val type: String
     ) : Route
     @Serializable
-    data object SelfDiagnosisResult : Route
+    data class SelfDiagnosisResult(
+        val type: String
+    ) : Route
 }

--- a/app/src/main/java/com/konkuk/strhat/core/util/KeyStorage.kt
+++ b/app/src/main/java/com/konkuk/strhat/core/util/KeyStorage.kt
@@ -10,4 +10,7 @@ object KeyStorage {
 
     // year picker
     const val MIN_YEAR = 2000
+
+    // 서버 통신
+    const val WEEKLY_DIARY_NOT_FOUND = 404
 }

--- a/app/src/main/java/com/konkuk/strhat/data/datasource/SelfDiagnosisDataSource.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/datasource/SelfDiagnosisDataSource.kt
@@ -1,10 +1,12 @@
 package com.konkuk.strhat.data.datasource
 
 import com.konkuk.strhat.data.dto.base.BaseResponse
+import com.konkuk.strhat.data.dto.request.RequestSelfDiagnosisDto
 import com.konkuk.strhat.data.dto.response.ResponseSelfDiagnosisQuestionDto
 import com.konkuk.strhat.data.dto.response.ResponseSelfDiagnosisResultDto
 
 interface SelfDiagnosisDataSource {
     suspend fun getSelfDiagnosisQuestionList(type: String): BaseResponse<List<ResponseSelfDiagnosisQuestionDto>>
     suspend fun getSelfDiagnosisResult(date: String, type: String): BaseResponse<ResponseSelfDiagnosisResultDto>
+    suspend fun postSelfDiagnosis(request: RequestSelfDiagnosisDto): BaseResponse<Unit>
 }

--- a/app/src/main/java/com/konkuk/strhat/data/datasource/SelfDiagnosisDataSource.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/datasource/SelfDiagnosisDataSource.kt
@@ -1,0 +1,8 @@
+package com.konkuk.strhat.data.datasource
+
+import com.konkuk.strhat.data.dto.base.BaseResponse
+import com.konkuk.strhat.data.dto.response.ResponseSelfDiagnosisQuestionDto
+
+interface SelfDiagnosisDataSource {
+    suspend fun getSelfDiagnosisQuestionList(type: String): BaseResponse<List<ResponseSelfDiagnosisQuestionDto>>
+}

--- a/app/src/main/java/com/konkuk/strhat/data/datasource/SelfDiagnosisDataSource.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/datasource/SelfDiagnosisDataSource.kt
@@ -2,7 +2,9 @@ package com.konkuk.strhat.data.datasource
 
 import com.konkuk.strhat.data.dto.base.BaseResponse
 import com.konkuk.strhat.data.dto.response.ResponseSelfDiagnosisQuestionDto
+import com.konkuk.strhat.data.dto.response.ResponseSelfDiagnosisResultDto
 
 interface SelfDiagnosisDataSource {
     suspend fun getSelfDiagnosisQuestionList(type: String): BaseResponse<List<ResponseSelfDiagnosisQuestionDto>>
+    suspend fun getSelfDiagnosisResult(date: String, type: String): BaseResponse<ResponseSelfDiagnosisResultDto>
 }

--- a/app/src/main/java/com/konkuk/strhat/data/datasource/StressScoreDataSource.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/datasource/StressScoreDataSource.kt
@@ -2,7 +2,9 @@ package com.konkuk.strhat.data.datasource
 
 import com.konkuk.strhat.data.dto.base.BaseResponse
 import com.konkuk.strhat.data.dto.response.ResponseStressScoreDto
+import com.konkuk.strhat.data.dto.response.ResponseWeeklyStressScoreDto
 
 interface StressScoreDataSource {
     suspend fun getStressScore(date: String): BaseResponse<ResponseStressScoreDto>
+    suspend fun getWeeklyStressScore(date: String): BaseResponse<ResponseWeeklyStressScoreDto>
 }

--- a/app/src/main/java/com/konkuk/strhat/data/datasourceimpl/SelfDiagnosisDataSourceImpl.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/datasourceimpl/SelfDiagnosisDataSourceImpl.kt
@@ -2,6 +2,7 @@ package com.konkuk.strhat.data.datasourceimpl
 
 import com.konkuk.strhat.data.datasource.SelfDiagnosisDataSource
 import com.konkuk.strhat.data.dto.base.BaseResponse
+import com.konkuk.strhat.data.dto.request.RequestSelfDiagnosisDto
 import com.konkuk.strhat.data.dto.response.ResponseSelfDiagnosisQuestionDto
 import com.konkuk.strhat.data.dto.response.ResponseSelfDiagnosisResultDto
 import com.konkuk.strhat.data.service.SelfDiagnosisService
@@ -15,4 +16,7 @@ class SelfDiagnosisDataSourceImpl @Inject constructor(
 
     override suspend fun getSelfDiagnosisResult(date: String, type: String): BaseResponse<ResponseSelfDiagnosisResultDto> =
         selfDiagnosisService.getSelfDiagnosisResult(date, type)
+
+    override suspend fun postSelfDiagnosis(request: RequestSelfDiagnosisDto): BaseResponse<Unit> =
+        selfDiagnosisService.postSelfDiagnosis(request)
 }

--- a/app/src/main/java/com/konkuk/strhat/data/datasourceimpl/SelfDiagnosisDataSourceImpl.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/datasourceimpl/SelfDiagnosisDataSourceImpl.kt
@@ -3,6 +3,7 @@ package com.konkuk.strhat.data.datasourceimpl
 import com.konkuk.strhat.data.datasource.SelfDiagnosisDataSource
 import com.konkuk.strhat.data.dto.base.BaseResponse
 import com.konkuk.strhat.data.dto.response.ResponseSelfDiagnosisQuestionDto
+import com.konkuk.strhat.data.dto.response.ResponseSelfDiagnosisResultDto
 import com.konkuk.strhat.data.service.SelfDiagnosisService
 import javax.inject.Inject
 
@@ -11,4 +12,7 @@ class SelfDiagnosisDataSourceImpl @Inject constructor(
 ) : SelfDiagnosisDataSource {
     override suspend fun getSelfDiagnosisQuestionList(type: String): BaseResponse<List<ResponseSelfDiagnosisQuestionDto>> =
         selfDiagnosisService.getSelfDiagnosisQuestionList(type)
+
+    override suspend fun getSelfDiagnosisResult(date: String, type: String): BaseResponse<ResponseSelfDiagnosisResultDto> =
+        selfDiagnosisService.getSelfDiagnosisResult(date, type)
 }

--- a/app/src/main/java/com/konkuk/strhat/data/datasourceimpl/SelfDiagnosisDataSourceImpl.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/datasourceimpl/SelfDiagnosisDataSourceImpl.kt
@@ -1,0 +1,14 @@
+package com.konkuk.strhat.data.datasourceimpl
+
+import com.konkuk.strhat.data.datasource.SelfDiagnosisDataSource
+import com.konkuk.strhat.data.dto.base.BaseResponse
+import com.konkuk.strhat.data.dto.response.ResponseSelfDiagnosisQuestionDto
+import com.konkuk.strhat.data.service.SelfDiagnosisService
+import javax.inject.Inject
+
+class SelfDiagnosisDataSourceImpl @Inject constructor(
+    private val selfDiagnosisService: SelfDiagnosisService
+) : SelfDiagnosisDataSource {
+    override suspend fun getSelfDiagnosisQuestionList(type: String): BaseResponse<List<ResponseSelfDiagnosisQuestionDto>> =
+        selfDiagnosisService.getSelfDiagnosisQuestionList(type)
+}

--- a/app/src/main/java/com/konkuk/strhat/data/datasourceimpl/StressScoreDataSourceImpl.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/datasourceimpl/StressScoreDataSourceImpl.kt
@@ -3,6 +3,7 @@ package com.konkuk.strhat.data.datasourceimpl
 import com.konkuk.strhat.data.datasource.StressScoreDataSource
 import com.konkuk.strhat.data.dto.base.BaseResponse
 import com.konkuk.strhat.data.dto.response.ResponseStressScoreDto
+import com.konkuk.strhat.data.dto.response.ResponseWeeklyStressScoreDto
 import com.konkuk.strhat.data.service.StressScoreService
 import javax.inject.Inject
 
@@ -11,4 +12,7 @@ class StressScoreDataSourceImpl @Inject constructor(
 ) : StressScoreDataSource {
     override suspend fun getStressScore(date: String): BaseResponse<ResponseStressScoreDto> =
         stressScoreService.getStressScore(date)
+
+    override suspend fun getWeeklyStressScore(date: String): BaseResponse<ResponseWeeklyStressScoreDto> =
+        stressScoreService.getWeeklyStressScore(date)
 }

--- a/app/src/main/java/com/konkuk/strhat/data/di/ApiModule.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/di/ApiModule.kt
@@ -5,6 +5,7 @@ import com.konkuk.strhat.data.service.ChatService
 import com.konkuk.strhat.data.service.DiaryService
 import com.konkuk.strhat.data.service.HomeService
 import com.konkuk.strhat.data.service.ReIssueService
+import com.konkuk.strhat.data.service.SelfDiagnosisService
 import com.konkuk.strhat.data.service.UserService
 import com.konkuk.strhat.data.service.StressScoreService
 import dagger.Module
@@ -51,4 +52,9 @@ object ApiModule {
     @Singleton
     fun providesChatService(retrofit: Retrofit): ChatService =
         retrofit.create(ChatService::class.java)
+
+    @Provides
+    @Singleton
+    fun providesSelfDiagnosisService(retrofit: Retrofit): SelfDiagnosisService =
+        retrofit.create(SelfDiagnosisService::class.java)
 }

--- a/app/src/main/java/com/konkuk/strhat/data/di/DataSourceModule.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/di/DataSourceModule.kt
@@ -4,12 +4,14 @@ import com.konkuk.strhat.data.datasource.AuthDataSource
 import com.konkuk.strhat.data.datasource.ChatDataSource
 import com.konkuk.strhat.data.datasource.DiaryDataSource
 import com.konkuk.strhat.data.datasource.HomeDataSource
+import com.konkuk.strhat.data.datasource.SelfDiagnosisDataSource
 import com.konkuk.strhat.data.datasource.UserDataSource
 import com.konkuk.strhat.data.datasource.StressScoreDataSource
 import com.konkuk.strhat.data.datasourceimpl.AuthDataSourceImpl
 import com.konkuk.strhat.data.datasourceimpl.ChatDataSourceImpl
 import com.konkuk.strhat.data.datasourceimpl.DiaryDataSourceImpl
 import com.konkuk.strhat.data.datasourceimpl.HomeDataSourceImpl
+import com.konkuk.strhat.data.datasourceimpl.SelfDiagnosisDataSourceImpl
 import com.konkuk.strhat.data.datasourceimpl.UserDataSourceImpl
 import com.konkuk.strhat.data.datasourceimpl.StressScoreDataSourceImpl
 import dagger.Binds
@@ -44,4 +46,8 @@ abstract class DataSourceModule {
     @Binds
     @Singleton
     abstract fun bindsChatDataSource(chatDataSourceImpl: ChatDataSourceImpl): ChatDataSource
+
+    @Binds
+    @Singleton
+    abstract fun bindsSelfDiagnosisDataSource(selfDiagnosisDataSourceImpl: SelfDiagnosisDataSourceImpl): SelfDiagnosisDataSource
 }

--- a/app/src/main/java/com/konkuk/strhat/data/di/RepositoryModule.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/di/RepositoryModule.kt
@@ -4,12 +4,14 @@ import com.konkuk.strhat.data.repositoryimpl.AuthRepositoryImpl
 import com.konkuk.strhat.data.repositoryimpl.ChatRepositoryImpl
 import com.konkuk.strhat.data.repositoryimpl.DiaryRepositoryImpl
 import com.konkuk.strhat.data.repositoryimpl.HomeRepositoryImpl
+import com.konkuk.strhat.data.repositoryimpl.SelfDiagnosisRepositoryImpl
 import com.konkuk.strhat.data.repositoryimpl.UserRepositoryImpl
 import com.konkuk.strhat.data.repositoryimpl.StressScoreRepositoryImpl
 import com.konkuk.strhat.domain.repository.AuthRepository
 import com.konkuk.strhat.domain.repository.ChatRepository
 import com.konkuk.strhat.domain.repository.DiaryRepository
 import com.konkuk.strhat.domain.repository.HomeRepository
+import com.konkuk.strhat.domain.repository.SelfDiagnosisRepository
 import com.konkuk.strhat.domain.repository.UserRepository
 import com.konkuk.strhat.domain.repository.StressScoreRepository
 import dagger.Binds
@@ -44,4 +46,8 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindsChatRepository(chatRepositoryImpl: ChatRepositoryImpl): ChatRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindsSelfDiagnosisRepository(selfDiagnosisRepositoryImpl: SelfDiagnosisRepositoryImpl): SelfDiagnosisRepository
 }

--- a/app/src/main/java/com/konkuk/strhat/data/dto/request/RequestSelfDiagnosisDto.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/dto/request/RequestSelfDiagnosisDto.kt
@@ -1,0 +1,9 @@
+package com.konkuk.strhat.data.dto.request
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RequestSelfDiagnosisDto(
+    val type: String,
+    val selfDiagnosisScore: Int
+)

--- a/app/src/main/java/com/konkuk/strhat/data/dto/response/ResponseSelfDiagnosisQuestionDto.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/dto/response/ResponseSelfDiagnosisQuestionDto.kt
@@ -1,0 +1,9 @@
+package com.konkuk.strhat.data.dto.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ResponseSelfDiagnosisQuestionDto(
+    val selfDiagnosisIndex: Int,
+    val selfDiagnosisQuestion: String
+)

--- a/app/src/main/java/com/konkuk/strhat/data/dto/response/ResponseSelfDiagnosisResultDto.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/dto/response/ResponseSelfDiagnosisResultDto.kt
@@ -1,0 +1,11 @@
+package com.konkuk.strhat.data.dto.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ResponseSelfDiagnosisResultDto(
+    val nickname: String,
+    val score: Int ?= null,
+    val type: String ?= null,
+    val selfDiagnosisLevel: String ?= null
+)

--- a/app/src/main/java/com/konkuk/strhat/data/dto/response/ResponseWeeklyStressScoreDto.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/dto/response/ResponseWeeklyStressScoreDto.kt
@@ -1,0 +1,13 @@
+package com.konkuk.strhat.data.dto.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ResponseWeeklyStressScoreDto(
+    val nickname: String,
+    val weeklySummary: String,
+    val stressLevels: List<Int?>,
+    val emotionLevels: List<Int?>,
+    val startDate: String,
+    val endDate: String
+)

--- a/app/src/main/java/com/konkuk/strhat/data/mapper/SelfDiagnosisMapper.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/mapper/SelfDiagnosisMapper.kt
@@ -1,8 +1,10 @@
 package com.konkuk.strhat.data.mapper
 
+import com.konkuk.strhat.data.dto.request.RequestSelfDiagnosisDto
 import com.konkuk.strhat.data.dto.response.ResponseSelfDiagnosisQuestionDto
 import com.konkuk.strhat.data.dto.response.ResponseSelfDiagnosisResultDto
 import com.konkuk.strhat.domain.entity.SelfDiagnosisItem
+import com.konkuk.strhat.domain.entity.SelfDiagnosisModel
 import com.konkuk.strhat.domain.entity.SelfDiagnosisResultModel
 
 fun ResponseSelfDiagnosisQuestionDto.toSelfDiagnosisQuestionModel() = SelfDiagnosisItem(
@@ -20,4 +22,9 @@ fun ResponseSelfDiagnosisResultDto.toSelfDiagnosisResultModel() = SelfDiagnosisR
     score = score,
     type = type,
     selfDiagnosisLevel = selfDiagnosisLevel
+)
+
+fun SelfDiagnosisModel.toSelfDiagnosisRequestDto() = RequestSelfDiagnosisDto(
+    type = type,
+    selfDiagnosisScore = selfDiagnosisScore
 )

--- a/app/src/main/java/com/konkuk/strhat/data/mapper/SelfDiagnosisMapper.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/mapper/SelfDiagnosisMapper.kt
@@ -1,0 +1,14 @@
+package com.konkuk.strhat.data.mapper
+
+import com.konkuk.strhat.data.dto.response.ResponseSelfDiagnosisQuestionDto
+import com.konkuk.strhat.domain.entity.SelfDiagnosisItem
+
+fun ResponseSelfDiagnosisQuestionDto.toSelfDiagnosisQuestionModel() = SelfDiagnosisItem(
+    selfDiagnosisIndex = selfDiagnosisIndex,
+    selfDiagnosisQuestion = selfDiagnosisQuestion
+)
+
+fun List<ResponseSelfDiagnosisQuestionDto>.toSelfDiagnosisQuestionListModel(): List<SelfDiagnosisItem> =
+    this.map {
+        it.toSelfDiagnosisQuestionModel()
+    }

--- a/app/src/main/java/com/konkuk/strhat/data/mapper/SelfDiagnosisMapper.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/mapper/SelfDiagnosisMapper.kt
@@ -1,7 +1,9 @@
 package com.konkuk.strhat.data.mapper
 
 import com.konkuk.strhat.data.dto.response.ResponseSelfDiagnosisQuestionDto
+import com.konkuk.strhat.data.dto.response.ResponseSelfDiagnosisResultDto
 import com.konkuk.strhat.domain.entity.SelfDiagnosisItem
+import com.konkuk.strhat.domain.entity.SelfDiagnosisResultModel
 
 fun ResponseSelfDiagnosisQuestionDto.toSelfDiagnosisQuestionModel() = SelfDiagnosisItem(
     selfDiagnosisIndex = selfDiagnosisIndex,
@@ -12,3 +14,10 @@ fun List<ResponseSelfDiagnosisQuestionDto>.toSelfDiagnosisQuestionListModel(): L
     this.map {
         it.toSelfDiagnosisQuestionModel()
     }
+
+fun ResponseSelfDiagnosisResultDto.toSelfDiagnosisResultModel() = SelfDiagnosisResultModel(
+    nickname = nickname,
+    score = score,
+    type = type,
+    selfDiagnosisLevel = selfDiagnosisLevel
+)

--- a/app/src/main/java/com/konkuk/strhat/data/mapper/StressScoreMapper.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/mapper/StressScoreMapper.kt
@@ -1,7 +1,9 @@
 package com.konkuk.strhat.data.mapper
 
 import com.konkuk.strhat.data.dto.response.ResponseStressScoreDto
+import com.konkuk.strhat.data.dto.response.ResponseWeeklyStressScoreDto
 import com.konkuk.strhat.domain.entity.StressScoreModel
+import com.konkuk.strhat.domain.entity.WeeklyStressScoreModel
 
 fun ResponseStressScoreDto.toStressScoreModel() = StressScoreModel(
     nickname = nickname,
@@ -9,4 +11,13 @@ fun ResponseStressScoreDto.toStressScoreModel() = StressScoreModel(
     level = level,
     analysis = analysis,
     stressScoreDate = stressScoreDate
+)
+
+fun ResponseWeeklyStressScoreDto.toWeeklyStressScoreModel() = WeeklyStressScoreModel(
+    nickname = nickname,
+    weeklySummary = weeklySummary,
+    stressLevels = stressLevels,
+    emotionLevels = emotionLevels,
+    startDate = startDate,
+    endDate = endDate
 )

--- a/app/src/main/java/com/konkuk/strhat/data/repositoryimpl/SelfDiagnosisRepositoryImpl.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/repositoryimpl/SelfDiagnosisRepositoryImpl.kt
@@ -1,0 +1,17 @@
+package com.konkuk.strhat.data.repositoryimpl
+
+import com.konkuk.strhat.data.datasource.SelfDiagnosisDataSource
+import com.konkuk.strhat.data.mapper.toSelfDiagnosisQuestionListModel
+import com.konkuk.strhat.domain.entity.SelfDiagnosisItem
+import com.konkuk.strhat.domain.repository.SelfDiagnosisRepository
+import javax.inject.Inject
+
+class SelfDiagnosisRepositoryImpl @Inject constructor(
+    private val selfDiagnosisDataSource: SelfDiagnosisDataSource
+) : SelfDiagnosisRepository {
+    override suspend fun getSelfDiagnosisQuestionList(type: String): Result<List<SelfDiagnosisItem>> =
+        runCatching {
+            val response = selfDiagnosisDataSource.getSelfDiagnosisQuestionList(type).response
+            response.toSelfDiagnosisQuestionListModel()
+        }
+}

--- a/app/src/main/java/com/konkuk/strhat/data/repositoryimpl/SelfDiagnosisRepositoryImpl.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/repositoryimpl/SelfDiagnosisRepositoryImpl.kt
@@ -2,7 +2,9 @@ package com.konkuk.strhat.data.repositoryimpl
 
 import com.konkuk.strhat.data.datasource.SelfDiagnosisDataSource
 import com.konkuk.strhat.data.mapper.toSelfDiagnosisQuestionListModel
+import com.konkuk.strhat.data.mapper.toSelfDiagnosisResultModel
 import com.konkuk.strhat.domain.entity.SelfDiagnosisItem
+import com.konkuk.strhat.domain.entity.SelfDiagnosisResultModel
 import com.konkuk.strhat.domain.repository.SelfDiagnosisRepository
 import javax.inject.Inject
 
@@ -13,5 +15,11 @@ class SelfDiagnosisRepositoryImpl @Inject constructor(
         runCatching {
             val response = selfDiagnosisDataSource.getSelfDiagnosisQuestionList(type).response
             response.toSelfDiagnosisQuestionListModel()
+        }
+
+    override suspend fun getSelfDiagnosisResult(date: String, type: String): Result<SelfDiagnosisResultModel> =
+        runCatching {
+            val response = selfDiagnosisDataSource.getSelfDiagnosisResult(date, type).response
+            response.toSelfDiagnosisResultModel()
         }
 }

--- a/app/src/main/java/com/konkuk/strhat/data/repositoryimpl/SelfDiagnosisRepositoryImpl.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/repositoryimpl/SelfDiagnosisRepositoryImpl.kt
@@ -2,8 +2,10 @@ package com.konkuk.strhat.data.repositoryimpl
 
 import com.konkuk.strhat.data.datasource.SelfDiagnosisDataSource
 import com.konkuk.strhat.data.mapper.toSelfDiagnosisQuestionListModel
+import com.konkuk.strhat.data.mapper.toSelfDiagnosisRequestDto
 import com.konkuk.strhat.data.mapper.toSelfDiagnosisResultModel
 import com.konkuk.strhat.domain.entity.SelfDiagnosisItem
+import com.konkuk.strhat.domain.entity.SelfDiagnosisModel
 import com.konkuk.strhat.domain.entity.SelfDiagnosisResultModel
 import com.konkuk.strhat.domain.repository.SelfDiagnosisRepository
 import javax.inject.Inject
@@ -21,5 +23,11 @@ class SelfDiagnosisRepositoryImpl @Inject constructor(
         runCatching {
             val response = selfDiagnosisDataSource.getSelfDiagnosisResult(date, type).response
             response.toSelfDiagnosisResultModel()
+        }
+
+    override suspend fun postSelfDiagnosis(request: SelfDiagnosisModel): Result<Unit> =
+        runCatching {
+            val response = selfDiagnosisDataSource.postSelfDiagnosis(request.toSelfDiagnosisRequestDto()).response
+            response
         }
 }

--- a/app/src/main/java/com/konkuk/strhat/data/repositoryimpl/StressScoreRepositoryImpl.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/repositoryimpl/StressScoreRepositoryImpl.kt
@@ -2,7 +2,9 @@ package com.konkuk.strhat.data.repositoryimpl
 
 import com.konkuk.strhat.data.datasource.StressScoreDataSource
 import com.konkuk.strhat.data.mapper.toStressScoreModel
+import com.konkuk.strhat.data.mapper.toWeeklyStressScoreModel
 import com.konkuk.strhat.domain.entity.StressScoreModel
+import com.konkuk.strhat.domain.entity.WeeklyStressScoreModel
 import com.konkuk.strhat.domain.repository.StressScoreRepository
 import javax.inject.Inject
 
@@ -13,5 +15,11 @@ class StressScoreRepositoryImpl @Inject constructor(
         runCatching {
             val response = stressScoreDataSource.getStressScore(date).response
             response.toStressScoreModel()
+        }
+
+    override suspend fun getWeeklyStressScore(date: String): Result<WeeklyStressScoreModel> =
+        runCatching {
+            val response = stressScoreDataSource.getWeeklyStressScore(date).response
+            response.toWeeklyStressScoreModel()
         }
 }

--- a/app/src/main/java/com/konkuk/strhat/data/service/SelfDiagnosisService.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/service/SelfDiagnosisService.kt
@@ -2,6 +2,7 @@ package com.konkuk.strhat.data.service
 
 import com.konkuk.strhat.data.dto.base.BaseResponse
 import com.konkuk.strhat.data.dto.response.ResponseSelfDiagnosisQuestionDto
+import com.konkuk.strhat.data.dto.response.ResponseSelfDiagnosisResultDto
 import retrofit2.http.GET
 import retrofit2.http.Query
 
@@ -10,4 +11,10 @@ interface SelfDiagnosisService {
     suspend fun getSelfDiagnosisQuestionList(
         @Query("type") type: String
     ): BaseResponse<List<ResponseSelfDiagnosisQuestionDto>>
+
+    @GET("/api/v1/self-diagnoses/result")
+    suspend fun getSelfDiagnosisResult(
+        @Query("date") date: String,
+        @Query("type") type: String
+    ): BaseResponse<ResponseSelfDiagnosisResultDto>
 }

--- a/app/src/main/java/com/konkuk/strhat/data/service/SelfDiagnosisService.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/service/SelfDiagnosisService.kt
@@ -1,0 +1,13 @@
+package com.konkuk.strhat.data.service
+
+import com.konkuk.strhat.data.dto.base.BaseResponse
+import com.konkuk.strhat.data.dto.response.ResponseSelfDiagnosisQuestionDto
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface SelfDiagnosisService {
+    @GET("/api/v1/self-diagnoses")
+    suspend fun getSelfDiagnosisQuestionList(
+        @Query("type") type: String
+    ): BaseResponse<List<ResponseSelfDiagnosisQuestionDto>>
+}

--- a/app/src/main/java/com/konkuk/strhat/data/service/SelfDiagnosisService.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/service/SelfDiagnosisService.kt
@@ -1,9 +1,12 @@
 package com.konkuk.strhat.data.service
 
 import com.konkuk.strhat.data.dto.base.BaseResponse
+import com.konkuk.strhat.data.dto.request.RequestSelfDiagnosisDto
 import com.konkuk.strhat.data.dto.response.ResponseSelfDiagnosisQuestionDto
 import com.konkuk.strhat.data.dto.response.ResponseSelfDiagnosisResultDto
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.POST
 import retrofit2.http.Query
 
 interface SelfDiagnosisService {
@@ -17,4 +20,9 @@ interface SelfDiagnosisService {
         @Query("date") date: String,
         @Query("type") type: String
     ): BaseResponse<ResponseSelfDiagnosisResultDto>
+
+    @POST("/api/v1/self-diagnoses")
+    suspend fun postSelfDiagnosis(
+        @Body request: RequestSelfDiagnosisDto
+    ): BaseResponse<Unit>
 }

--- a/app/src/main/java/com/konkuk/strhat/data/service/StressScoreService.kt
+++ b/app/src/main/java/com/konkuk/strhat/data/service/StressScoreService.kt
@@ -2,6 +2,7 @@ package com.konkuk.strhat.data.service
 
 import com.konkuk.strhat.data.dto.base.BaseResponse
 import com.konkuk.strhat.data.dto.response.ResponseStressScoreDto
+import com.konkuk.strhat.data.dto.response.ResponseWeeklyStressScoreDto
 import retrofit2.http.GET
 import retrofit2.http.Query
 
@@ -10,4 +11,9 @@ interface StressScoreService {
     suspend fun getStressScore(
         @Query("date") date: String
     ): BaseResponse<ResponseStressScoreDto>
+
+    @GET("api/v1/stress-score/weekly")
+    suspend fun getWeeklyStressScore(
+        @Query("date") date: String
+    ): BaseResponse<ResponseWeeklyStressScoreDto>
 }

--- a/app/src/main/java/com/konkuk/strhat/domain/entity/SelfDiagnosisItem.kt
+++ b/app/src/main/java/com/konkuk/strhat/domain/entity/SelfDiagnosisItem.kt
@@ -1,0 +1,9 @@
+package com.konkuk.strhat.domain.entity
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SelfDiagnosisItem(
+    val selfDiagnosisIndex: Int,
+    val selfDiagnosisQuestion: String
+)

--- a/app/src/main/java/com/konkuk/strhat/domain/entity/SelfDiagnosisModel.kt
+++ b/app/src/main/java/com/konkuk/strhat/domain/entity/SelfDiagnosisModel.kt
@@ -1,0 +1,9 @@
+package com.konkuk.strhat.domain.entity
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SelfDiagnosisModel(
+    val type: String,
+    val selfDiagnosisScore: Int
+)

--- a/app/src/main/java/com/konkuk/strhat/domain/entity/SelfDiagnosisResultModel.kt
+++ b/app/src/main/java/com/konkuk/strhat/domain/entity/SelfDiagnosisResultModel.kt
@@ -1,0 +1,11 @@
+package com.konkuk.strhat.domain.entity
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SelfDiagnosisResultModel(
+    val nickname: String,
+    val score: Int ?= null,
+    val type: String ?= null,
+    val selfDiagnosisLevel: String ?= null
+)

--- a/app/src/main/java/com/konkuk/strhat/domain/entity/WeeklyStressScoreModel.kt
+++ b/app/src/main/java/com/konkuk/strhat/domain/entity/WeeklyStressScoreModel.kt
@@ -1,0 +1,13 @@
+package com.konkuk.strhat.domain.entity
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class WeeklyStressScoreModel(
+    val nickname: String,
+    val weeklySummary: String,
+    val stressLevels: List<Int?>,
+    val emotionLevels: List<Int?>,
+    val startDate: String,
+    val endDate: String
+)

--- a/app/src/main/java/com/konkuk/strhat/domain/repository/SelfDiagnosisRepository.kt
+++ b/app/src/main/java/com/konkuk/strhat/domain/repository/SelfDiagnosisRepository.kt
@@ -1,0 +1,7 @@
+package com.konkuk.strhat.domain.repository
+
+import com.konkuk.strhat.domain.entity.SelfDiagnosisItem
+
+interface SelfDiagnosisRepository {
+    suspend fun getSelfDiagnosisQuestionList(type: String): Result<List<SelfDiagnosisItem>>
+}

--- a/app/src/main/java/com/konkuk/strhat/domain/repository/SelfDiagnosisRepository.kt
+++ b/app/src/main/java/com/konkuk/strhat/domain/repository/SelfDiagnosisRepository.kt
@@ -1,7 +1,9 @@
 package com.konkuk.strhat.domain.repository
 
 import com.konkuk.strhat.domain.entity.SelfDiagnosisItem
+import com.konkuk.strhat.domain.entity.SelfDiagnosisResultModel
 
 interface SelfDiagnosisRepository {
     suspend fun getSelfDiagnosisQuestionList(type: String): Result<List<SelfDiagnosisItem>>
+    suspend fun getSelfDiagnosisResult(date: String, type: String): Result<SelfDiagnosisResultModel>
 }

--- a/app/src/main/java/com/konkuk/strhat/domain/repository/SelfDiagnosisRepository.kt
+++ b/app/src/main/java/com/konkuk/strhat/domain/repository/SelfDiagnosisRepository.kt
@@ -1,9 +1,11 @@
 package com.konkuk.strhat.domain.repository
 
 import com.konkuk.strhat.domain.entity.SelfDiagnosisItem
+import com.konkuk.strhat.domain.entity.SelfDiagnosisModel
 import com.konkuk.strhat.domain.entity.SelfDiagnosisResultModel
 
 interface SelfDiagnosisRepository {
     suspend fun getSelfDiagnosisQuestionList(type: String): Result<List<SelfDiagnosisItem>>
     suspend fun getSelfDiagnosisResult(date: String, type: String): Result<SelfDiagnosisResultModel>
+    suspend fun postSelfDiagnosis(request: SelfDiagnosisModel): Result<Unit>
 }

--- a/app/src/main/java/com/konkuk/strhat/domain/repository/StressScoreRepository.kt
+++ b/app/src/main/java/com/konkuk/strhat/domain/repository/StressScoreRepository.kt
@@ -1,7 +1,9 @@
 package com.konkuk.strhat.domain.repository
 
 import com.konkuk.strhat.domain.entity.StressScoreModel
+import com.konkuk.strhat.domain.entity.WeeklyStressScoreModel
 
 interface StressScoreRepository {
     suspend fun getStressScore(date: String): Result<StressScoreModel>
+    suspend fun getWeeklyStressScore(date: String): Result<WeeklyStressScoreModel>
 }

--- a/app/src/main/java/com/konkuk/strhat/domain/type/SelfDiagnosisTestType.kt
+++ b/app/src/main/java/com/konkuk/strhat/domain/type/SelfDiagnosisTestType.kt
@@ -1,0 +1,9 @@
+package com.konkuk.strhat.domain.type
+
+enum class SelfDiagnosisTestType(
+    val testType: String
+) {
+    PSS("pss"),
+    SRI("sri"),
+    PHQ9("phq9")
+}

--- a/app/src/main/java/com/konkuk/strhat/feature/diary/DiaryAIFeedbackRecordScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/diary/DiaryAIFeedbackRecordScreen.kt
@@ -224,15 +224,9 @@ fun DiaryAIFeedbackRecordScreen(
         Row(
             horizontalArrangement = Arrangement.spacedBy(40.dp)
         ) {
-            val isDiaryRoute = previousRoute?.contains("Diary") == true
-
             StrHatButton(
                 isDisabled = false,
-                text =
-                if (isDiaryRoute)
-                    stringResource(R.string.confirm)
-                else
-                    stringResource(R.string.diary_ai_feedback_quit_button),
+                text = stringResource(R.string.confirm),
                 modifier = Modifier
                     .padding(bottom = 20.dp)
                     .weight(1f),
@@ -240,19 +234,12 @@ fun DiaryAIFeedbackRecordScreen(
             )
             StrHatButton(
                 isDisabled = false,
-                text =
-                if (previousRoute?.contains("Diary") == true)
-                    stringResource(R.string.my_page_ai_feedback_chat_history_button)
-                else
-                    stringResource(R.string.diary_ai_feedback_chat_button),
+                text = stringResource(R.string.my_page_ai_feedback_chat_history_button),
                 modifier = Modifier
                     .padding(bottom = 20.dp)
                     .weight(1f),
                 onClick = {
-                    if (previousRoute?.contains("Diary") == true)
-                        navigateToMyPageChatHistory(diaryFeedbackModel.diaryId)
-                    else
-                        isChatModeBottomSheetVisible = true
+                    navigateToMyPageChatHistory(diaryFeedbackModel.diaryId)
                 }
             )
         }

--- a/app/src/main/java/com/konkuk/strhat/feature/diary/StressScoreViewModel.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/diary/StressScoreViewModel.kt
@@ -41,6 +41,8 @@ class StressScoreViewModel @Inject constructor(
                         if (it is HttpException) {
                             val errorBody = it.response()?.errorBody()?.string()
                             Timber.tag("get stress score").e("$errorBody")
+                        } else {
+                            Timber.tag("get stress score").e(it, "스트레스 점수 조회 실패")
                         }
                     }
             } catch (e: Exception) {

--- a/app/src/main/java/com/konkuk/strhat/feature/diary/TodayStressScoreScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/diary/TodayStressScoreScreen.kt
@@ -83,6 +83,13 @@ fun TodayStressScoreScreen(
         navController.previousBackStackEntry?.destination?.route
     }
 
+    val stressScoreColor =
+        when (stressScoreState.stressScore) {
+            in 1 .. 5 -> colors.MainBlue
+            in 9 .. 10 -> colors.MainRed
+            else -> colors.Gray400
+        }
+
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -118,7 +125,7 @@ fun TodayStressScoreScreen(
                 Text(
                     text = stressScoreState.stressScore.toString(),
                     style = typography.head0_b_26,
-                    color = colors.Gray400,
+                    color = stressScoreColor,
                     modifier = Modifier.align(Alignment.CenterVertically)
                 )
 
@@ -137,7 +144,7 @@ fun TodayStressScoreScreen(
                 Text(
                     text = stressScoreState.level,
                     style = typography.head2_b_20,
-                    color = colors.Gray400,
+                    color = stressScoreColor,
                     modifier = Modifier.align(Alignment.CenterVertically)
                 )
                 Text(

--- a/app/src/main/java/com/konkuk/strhat/feature/diary/navigation/DiaryNavigation.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/diary/navigation/DiaryNavigation.kt
@@ -25,8 +25,8 @@ fun NavController.navigateToAddDiary() {
     navigate(DiaryRoute.AddDiary)
 }
 
-fun NavController.navigateToMyPageDiaryAIFeedback() {
-    navigate(DiaryRoute.DiaryAIFeedback)
+fun NavController.navigateToMyPageDiaryAIFeedback(date: String) {
+    navigate(DiaryRoute.DiaryAIFeedbackRecord(date))
 }
 
 fun NavController.navigateToDiaryAIFeedback(date: String, summary: String, positiveKeywords: List<String>, negativeKeywords: List<String>, stressReliefSuggestions: String, diaryId: Int) {

--- a/app/src/main/java/com/konkuk/strhat/feature/main/MainNavigator.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/main/MainNavigator.kt
@@ -166,8 +166,8 @@ class MainNavigator(
         navController.navigateToTodayStressScore(date)
     }
 
-    fun navigateToChangeGraph() {
-        navController.navigateToChangeGraph()
+    fun navigateToChangeGraph(date: String) {
+        navController.navigateToChangeGraph(date)
     }
 
     fun navigateToSelfDiagnosisTest(type: String) {

--- a/app/src/main/java/com/konkuk/strhat/feature/main/MainNavigator.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/main/MainNavigator.kt
@@ -174,8 +174,8 @@ class MainNavigator(
         navController.navigateToSelfDiagnosisTest(type)
     }
 
-    fun navigateToSelfDiagnosisResult() {
-        navController.navigateToSelfDiagnosisResult()
+    fun navigateToSelfDiagnosisResult(type: String) {
+        navController.navigateToSelfDiagnosisResult(type)
     }
 
     fun navigateToMySelfDiagnosisRecord() {

--- a/app/src/main/java/com/konkuk/strhat/feature/main/MainNavigator.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/main/MainNavigator.kt
@@ -186,8 +186,8 @@ class MainNavigator(
         navController.navigateToMySelfDiagnosisRecordResult()
     }
 
-    fun navigateToMyPageStressScore() {
-        navController.navigateToMyPageStressScore()
+    fun navigateToMyPageStressScore(date: String) {
+        navController.navigateToMyPageStressScore(date)
     }
 
     fun navigateToMyPageChatHistory(diaryId: Int) {

--- a/app/src/main/java/com/konkuk/strhat/feature/main/MainNavigator.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/main/MainNavigator.kt
@@ -128,8 +128,8 @@ class MainNavigator(
         navController.navigateToAddDiary()
     }
 
-    fun navigateToMyPageDiaryAIFeedback() {
-        navController.navigateToMyPageDiaryAIFeedback()
+    fun navigateToMyPageDiaryAIFeedback(date: String) {
+        navController.navigateToMyPageDiaryAIFeedback(date)
     }
 
     fun navigateToDiaryAIFeedback(

--- a/app/src/main/java/com/konkuk/strhat/feature/main/MainNavigator.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/main/MainNavigator.kt
@@ -170,8 +170,8 @@ class MainNavigator(
         navController.navigateToChangeGraph()
     }
 
-    fun navigateToSelfDiagnosisTest() {
-        navController.navigateToSelfDiagnosisTest()
+    fun navigateToSelfDiagnosisTest(type: String) {
+        navController.navigateToSelfDiagnosisTest(type)
     }
 
     fun navigateToSelfDiagnosisResult() {

--- a/app/src/main/java/com/konkuk/strhat/feature/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/mypage/MyPageScreen.kt
@@ -1,6 +1,5 @@
 package com.konkuk.strhat.feature.mypage
 
-import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -8,10 +7,11 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -26,6 +26,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextDecoration
@@ -34,7 +35,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.hilt.navigation.compose.hiltViewModel
-import coil.compose.AsyncImage
 import com.konkuk.strhat.R
 import com.konkuk.strhat.core.component.dialog.StrHatDialog
 import com.konkuk.strhat.core.component.section.PageDescriptionSection
@@ -54,7 +54,7 @@ fun MyPageRoute(
     navigateToStress: () -> Unit,
     navigateToPersonality: () -> Unit,
     navigateToMySelfDiagnosisRecord: () -> Unit,
-    navigateToMyPageStressScore: () -> Unit,
+    navigateToMyPageStressScore: (String) -> Unit,
     navigateToChangeGraph: (String) -> Unit,
     viewModel: MyPageViewModel = hiltViewModel()
 ) {
@@ -85,7 +85,7 @@ private fun MyPageScreen(
     navigateToStress: () -> Unit,
     navigateToPersonality: () -> Unit,
     navigateToMySelfDiagnosisRecord: () -> Unit,
-    navigateToMyPageStressScore: () -> Unit,
+    navigateToMyPageStressScore: (String) -> Unit,
     navigateToChangeGraph: (String) -> Unit,
     onSignOutClick: () -> Unit,
     myPageModel: MyPageModel
@@ -105,8 +105,7 @@ private fun MyPageScreen(
 
         Row(
             modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween
+            verticalAlignment = Alignment.CenterVertically
         ) {
             Column(
                 modifier = Modifier
@@ -192,18 +191,16 @@ private fun MyPageScreen(
                 )
             }
 
+            Spacer(modifier = Modifier.width(20.dp))
+
             Image(
                 painter = painterResource(R.drawable.ic_strhat_yellow_shadow),
                 contentDescription = stringResource(R.string.my_image_description),
-                modifier = Modifier.size(140.dp)
-            )
-            AsyncImage(
-                model = "https://github.com/user-attachments/assets/e227846b-cb86-4f9d-8f0f-0c3a52ca4659",
-                contentDescription = null,
-                modifier = Modifier.size(140.dp),
-                onError = {
-                    Log.e("AsyncImage", "load failed", it.result.throwable)
-                }
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .padding(20.dp)
             )
         }
 
@@ -355,7 +352,8 @@ private fun MyPageScreen(
             modifier = Modifier
                 .padding(bottom = 15.dp)
                 .noRippleClickable {
-                    navigateToMyPageStressScore()
+                    val date = LocalDate.now().format(DateTimeFormatter.ISO_DATE)
+                    navigateToMyPageStressScore(date)
                 }
         )
         HorizontalDivider(

--- a/app/src/main/java/com/konkuk/strhat/feature/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/mypage/MyPageScreen.kt
@@ -1,5 +1,6 @@
 package com.konkuk.strhat.feature.mypage
 
+import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -33,6 +34,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.hilt.navigation.compose.hiltViewModel
+import coil.compose.AsyncImage
 import com.konkuk.strhat.R
 import com.konkuk.strhat.core.component.dialog.StrHatDialog
 import com.konkuk.strhat.core.component.section.PageDescriptionSection
@@ -40,6 +42,8 @@ import com.konkuk.strhat.core.util.modifier.noRippleClickable
 import com.konkuk.strhat.domain.entity.MyPageModel
 import com.konkuk.strhat.ui.theme.StrHatTheme.colors
 import com.konkuk.strhat.ui.theme.StrHatTheme.typography
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import java.util.Calendar
 
 @Composable
@@ -51,7 +55,7 @@ fun MyPageRoute(
     navigateToPersonality: () -> Unit,
     navigateToMySelfDiagnosisRecord: () -> Unit,
     navigateToMyPageStressScore: () -> Unit,
-    navigateToChangeGraph: () -> Unit,
+    navigateToChangeGraph: (String) -> Unit,
     viewModel: MyPageViewModel = hiltViewModel()
 ) {
     LaunchedEffect(Unit) {
@@ -82,7 +86,7 @@ private fun MyPageScreen(
     navigateToPersonality: () -> Unit,
     navigateToMySelfDiagnosisRecord: () -> Unit,
     navigateToMyPageStressScore: () -> Unit,
-    navigateToChangeGraph: () -> Unit,
+    navigateToChangeGraph: (String) -> Unit,
     onSignOutClick: () -> Unit,
     myPageModel: MyPageModel
 ) {
@@ -192,6 +196,14 @@ private fun MyPageScreen(
                 painter = painterResource(R.drawable.ic_strhat_yellow_shadow),
                 contentDescription = stringResource(R.string.my_image_description),
                 modifier = Modifier.size(140.dp)
+            )
+            AsyncImage(
+                model = "https://github.com/user-attachments/assets/e227846b-cb86-4f9d-8f0f-0c3a52ca4659",
+                contentDescription = null,
+                modifier = Modifier.size(140.dp),
+                onError = {
+                    Log.e("AsyncImage", "load failed", it.result.throwable)
+                }
             )
         }
 
@@ -326,7 +338,8 @@ private fun MyPageScreen(
             modifier = Modifier
                 .padding(bottom = 15.dp)
                 .noRippleClickable {
-                    navigateToChangeGraph()
+                    val date = LocalDate.now().format(DateTimeFormatter.ISO_DATE)
+                    navigateToChangeGraph(date)
                 }
         )
         HorizontalDivider(

--- a/app/src/main/java/com/konkuk/strhat/feature/mypage/MyPageStressScoreScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/mypage/MyPageStressScoreScreen.kt
@@ -58,6 +58,13 @@ fun MyPageStressScoreScreen(
     popBackStack: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val stressScoreColor =
+        when (stressScoreState.stressScore) {
+            in 1 .. 5 -> colors.MainBlue
+            in 9 .. 10 -> colors.MainRed
+            else -> colors.Gray400
+        }
+
     if (stressScoreState.analysis == "") {
         TodayStressScoreEmptyView(
             popBackStack = popBackStack
@@ -100,8 +107,10 @@ fun MyPageStressScoreScreen(
                     Text(
                         text = stressScoreState.stressScore.toString(),
                         style = typography.head0_b_26,
-                        color = colors.Gray400,
-                        modifier = Modifier.align(Alignment.CenterVertically)
+                        color = stressScoreColor,
+                        modifier = Modifier
+                            .padding(top = 4.dp)
+                            .align(Alignment.CenterVertically)
                     )
 
                     Spacer(modifier = Modifier.width(4.dp))
@@ -119,7 +128,7 @@ fun MyPageStressScoreScreen(
                     Text(
                         text = stressScoreState.level,
                         style = typography.head2_b_20,
-                        color = colors.Gray400,
+                        color = stressScoreColor,
                         modifier = Modifier.align(Alignment.CenterVertically)
                     )
                     Text(
@@ -168,7 +177,7 @@ fun MyPageStressScoreScreenPreview() {
     StrHatTheme {
         MyPageStressScoreScreen(
             padding = PaddingValues(),
-            stressScoreState = StressScoreModel("", 1, "", "", ""),
+            stressScoreState = StressScoreModel("", 1, "", "aa", ""),
             popBackStack = {}
         )
     }

--- a/app/src/main/java/com/konkuk/strhat/feature/mypage/MyPageStressScoreScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/mypage/MyPageStressScoreScreen.kt
@@ -29,21 +29,18 @@ import com.konkuk.strhat.feature.diary.StressScoreViewModel
 import com.konkuk.strhat.ui.theme.StrHatTheme
 import com.konkuk.strhat.ui.theme.StrHatTheme.colors
 import com.konkuk.strhat.ui.theme.StrHatTheme.typography
-import java.time.LocalDate
-import java.time.format.DateTimeFormatter
 
 @Composable
 fun MyPageStressScoreRoute(
     padding: PaddingValues,
+    date: String,
     popBackStack: () -> Unit,
     viewModel: StressScoreViewModel = hiltViewModel()
 ) {
     val stressScoreState by viewModel.stressScoreState.collectAsState()
 
-    val today = LocalDate.now().format(DateTimeFormatter.ISO_DATE)
-
     LaunchedEffect(Unit) {
-        viewModel.getStressScore(today)
+        viewModel.getStressScore(date)
     }
 
     MyPageStressScoreScreen(

--- a/app/src/main/java/com/konkuk/strhat/feature/mypage/MyPageStressScoreScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/mypage/MyPageStressScoreScreen.kt
@@ -26,6 +26,7 @@ import com.konkuk.strhat.core.component.button.StrHatButton
 import com.konkuk.strhat.core.component.section.PageDescriptionSection
 import com.konkuk.strhat.domain.entity.StressScoreModel
 import com.konkuk.strhat.feature.diary.StressScoreViewModel
+import com.konkuk.strhat.feature.mypage.component.TodayStressScoreEmptyView
 import com.konkuk.strhat.ui.theme.StrHatTheme
 import com.konkuk.strhat.ui.theme.StrHatTheme.colors
 import com.konkuk.strhat.ui.theme.StrHatTheme.typography
@@ -57,101 +58,107 @@ fun MyPageStressScoreScreen(
     popBackStack: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .background(colors.MainWhite)
-            .padding(top = 70.dp, start = 20.dp, end = 20.dp)
-    ) {
+    if (stressScoreState.analysis == "") {
+        TodayStressScoreEmptyView(
+            popBackStack = popBackStack
+        )
+    } else {
         Column(
-            modifier = Modifier
-                .weight(1f)
+            modifier = modifier
+                .fillMaxSize()
+                .background(colors.MainWhite)
+                .padding(top = 70.dp, start = 20.dp, end = 20.dp)
         ) {
-            Row {
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+            ) {
+                Row {
+                    Text(
+                        text = stressScoreState.nickname,
+                        style = typography.head1_b_24,
+                        color = colors.MainBlue
+                    )
+                    Text(
+                        text = stringResource(R.string.stress_score_nickname_description),
+                        style = typography.head1_b_24,
+                        color = colors.MainBlack
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Row {
+                    Text(
+                        text = stringResource(R.string.my_page_stress_score_title),
+                        style = typography.head1_b_24,
+                        color = colors.MainBlack
+                    )
+
+                    Spacer(modifier = Modifier.width(8.dp))
+
+                    Text(
+                        text = stressScoreState.stressScore.toString(),
+                        style = typography.head0_b_26,
+                        color = colors.Gray400,
+                        modifier = Modifier.align(Alignment.CenterVertically)
+                    )
+
+                    Spacer(modifier = Modifier.width(4.dp))
+
+                    Text(
+                        text = stringResource(R.string.stress_score_stress_score_end),
+                        style = typography.head1_b_24,
+                        color = colors.MainBlack
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(40.dp))
+
+                Row {
+                    Text(
+                        text = stressScoreState.level,
+                        style = typography.head2_b_20,
+                        color = colors.Gray400,
+                        modifier = Modifier.align(Alignment.CenterVertically)
+                    )
+                    Text(
+                        text = stringResource(R.string.stress_score_level_end),
+                        style = typography.head2_r_20,
+                        color = colors.MainBlack
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(4.dp))
+
                 Text(
-                    text = stressScoreState.nickname,
-                    style = typography.head1_b_24,
-                    color = colors.MainBlue
-                )
-                Text(
-                    text = stringResource(R.string.stress_score_nickname_description),
-                    style = typography.head1_b_24,
+                    text = stringResource(R.string.stress_score_level_description),
+                    style = typography.body2_r_15,
                     color = colors.MainBlack
+                )
+
+                Spacer(modifier = Modifier.height(46.dp))
+
+                PageDescriptionSection(
+                    titleResId = R.string.stress_score_analysis_title
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                SummaryBox(
+                    summary = stressScoreState.analysis,
+                    backgroundColor = colors.Gray100
                 )
             }
 
-            Spacer(modifier = Modifier.height(8.dp))
-
-            Row {
-                Text(
-                    text = stringResource(R.string.my_page_stress_score_title),
-                    style = typography.head1_b_24,
-                    color = colors.MainBlack
-                )
-
-                Spacer(modifier = Modifier.width(8.dp))
-
-                Text(
-                    text = stressScoreState.stressScore.toString(),
-                    style = typography.head0_b_26,
-                    color = colors.Gray400,
-                    modifier = Modifier.align(Alignment.CenterVertically)
-                )
-
-                Spacer(modifier = Modifier.width(4.dp))
-
-                Text(
-                    text = stringResource(R.string.stress_score_stress_score_end),
-                    style = typography.head1_b_24,
-                    color = colors.MainBlack
-                )
-            }
-
-            Spacer(modifier = Modifier.height(40.dp))
-
-            Row {
-                Text(
-                    text = stressScoreState.level,
-                    style = typography.head2_b_20,
-                    color = colors.Gray400,
-                    modifier = Modifier.align(Alignment.CenterVertically)
-                )
-                Text(
-                    text = stringResource(R.string.stress_score_level_end),
-                    style = typography.head2_r_20,
-                    color = colors.MainBlack
-                )
-            }
-
-            Spacer(modifier = Modifier.height(4.dp))
-
-            Text(
-                text = stringResource(R.string.stress_score_level_description),
-                style = typography.body2_r_15,
-                color = colors.MainBlack
-            )
-
-            Spacer(modifier = Modifier.height(46.dp))
-
-            PageDescriptionSection(
-                titleResId = R.string.stress_score_analysis_title
-            )
-
-            Spacer(modifier = Modifier.height(16.dp))
-
-            SummaryBox(
-                summary = stressScoreState.analysis,
-                backgroundColor = colors.Gray100
+            StrHatButton(
+                text = stringResource(R.string.my_page_go_back_button),
+                onClick = {
+                    popBackStack()
+                },
+                modifier = Modifier.padding(bottom = 20.dp)
             )
         }
-
-        StrHatButton(
-            text = stringResource(R.string.my_page_go_back_button),
-            onClick = {
-                popBackStack()
-            },
-            modifier = Modifier.padding(bottom = 20.dp)
-        )
     }
 }
 

--- a/app/src/main/java/com/konkuk/strhat/feature/mypage/MySelfDiagnosisRecordResultScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/mypage/MySelfDiagnosisRecordResultScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -32,7 +33,9 @@ import com.konkuk.strhat.core.component.bottomsheet.DatePickerBottomSheet
 import com.konkuk.strhat.core.component.button.StrHatButton
 import com.konkuk.strhat.core.util.modifier.noRippleClickable
 import com.konkuk.strhat.core.util.time.currentDate
+import com.konkuk.strhat.domain.entity.SelfDiagnosisResultModel
 import com.konkuk.strhat.feature.mypage.state.MySelfDiagnosisRecordResultState
+import com.konkuk.strhat.feature.selfdiagnosis.SelfDiagnosisViewModel
 import com.konkuk.strhat.ui.theme.StrHatTheme
 import com.konkuk.strhat.ui.theme.StrHatTheme.colors
 import com.konkuk.strhat.ui.theme.StrHatTheme.typography
@@ -41,12 +44,19 @@ import com.konkuk.strhat.ui.theme.StrHatTheme.typography
 fun MySelfDiagnosisRecordResultRoute(
     padding: PaddingValues,
     navigateToMyPage: () -> Unit,
-    viewModel: MySelfDiagnosisRecordViewModel = hiltViewModel()
+    viewModel: MySelfDiagnosisRecordViewModel = hiltViewModel(),
+    selfDiagnosisViewModel: SelfDiagnosisViewModel = hiltViewModel()
 ) {
     val mySelfDiagnosisRecordResultState by viewModel.mySelfDiagnosisRecordResultState.collectAsState()
+    val selfDiagnosisRecordResultModel by selfDiagnosisViewModel.selfDiagnosisResultModel.collectAsState()
+
+    LaunchedEffect(Unit) {
+        selfDiagnosisViewModel.getSelfDiagnosisResult("2025-05-14", "pss")
+    }
 
     MySelfDiagnosisRecordResultScreen(
         padding = padding,
+        selfDiagnosisRecordResultModel = selfDiagnosisRecordResultModel,
         mySelfDiagnosisRecordResultState = mySelfDiagnosisRecordResultState,
         navigateToMyPage = navigateToMyPage
     )
@@ -55,6 +65,7 @@ fun MySelfDiagnosisRecordResultRoute(
 @Composable
 fun MySelfDiagnosisRecordResultScreen(
     padding: PaddingValues,
+    selfDiagnosisRecordResultModel: SelfDiagnosisResultModel,
     mySelfDiagnosisRecordResultState: MySelfDiagnosisRecordResultState,
     navigateToMyPage: () -> Unit,
     modifier: Modifier = Modifier
@@ -80,7 +91,7 @@ fun MySelfDiagnosisRecordResultScreen(
             ) {
                 Row {
                     Text(
-                        text = mySelfDiagnosisRecordResultState.nickname,
+                        text = selfDiagnosisRecordResultModel.nickname,
                         style = typography.head1_b_24,
                         color = colors.MainBlue
                     )
@@ -140,12 +151,14 @@ fun MySelfDiagnosisRecordResultScreen(
             Spacer(modifier = Modifier.height(8.dp))
 
             Row {
-                Text(
-                    text = mySelfDiagnosisRecordResultState.testType,
-                    style = typography.head0_b_26,
-                    color = colors.MainBlack,
-                    modifier = Modifier.align(Alignment.CenterVertically)
-                )
+                selfDiagnosisRecordResultModel.type?.let {
+                    Text(
+                        text = it,
+                        style = typography.head0_b_26,
+                        color = colors.MainBlack,
+                        modifier = Modifier.align(Alignment.CenterVertically)
+                    )
+                }
 
                 Spacer(modifier = Modifier.width(4.dp))
 
@@ -164,7 +177,7 @@ fun MySelfDiagnosisRecordResultScreen(
 
             Row {
                 Text(
-                    text = mySelfDiagnosisRecordResultState.stressScore.toString(),
+                    text = selfDiagnosisRecordResultModel.score.toString(),
                     style = typography.head0_b_26,
                     color = colors.MainBlue,
                     modifier = Modifier.align(Alignment.CenterVertically)
@@ -182,11 +195,13 @@ fun MySelfDiagnosisRecordResultScreen(
             Spacer(modifier = Modifier.height(30.dp))
 
             Row {
-                Text(
-                    text = mySelfDiagnosisRecordResultState.stressLevel,
-                    style = typography.head2_b_20,
-                    color = colors.MainBlue
-                )
+                selfDiagnosisRecordResultModel.selfDiagnosisLevel?.let {
+                    Text(
+                        text = it,
+                        style = typography.head2_b_20,
+                        color = colors.MainBlue
+                    )
+                }
                 Text(
                     text = stringResource(R.string.self_diagnosis_result_stress_level_end),
                     style = typography.head2_r_20,
@@ -250,6 +265,7 @@ fun MySelfDiagnosisResultScreenPreview() {
 
         MySelfDiagnosisRecordResultScreen(
             padding = PaddingValues(),
+            selfDiagnosisRecordResultModel = SelfDiagnosisResultModel("", 1, "", ""),
             mySelfDiagnosisRecordResultState = mySelfDiagnosisRecordResultExampleState,
             navigateToMyPage = {}
         )

--- a/app/src/main/java/com/konkuk/strhat/feature/mypage/MyStressEmotionChangeGraphScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/mypage/MyStressEmotionChangeGraphScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -50,7 +51,7 @@ fun MyStressEmotionChangeGraphRoute(
     navigateToMyPageAIFeedback: (String) -> Unit,
     viewModel: MyStressGraphViewModel = hiltViewModel()
 ) {
-    var weekOffset by remember { mutableIntStateOf(0) }
+    var weekOffset by rememberSaveable { mutableIntStateOf(0) }
     val initialDate = remember(date) { LocalDate.parse(date) }
 
     LaunchedEffect(weekOffset) {

--- a/app/src/main/java/com/konkuk/strhat/feature/mypage/MyStressEmotionChangeGraphScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/mypage/MyStressEmotionChangeGraphScreen.kt
@@ -46,7 +46,7 @@ import java.time.format.DateTimeFormatter
 fun MyStressEmotionChangeGraphRoute(
     padding: PaddingValues,
     date: String,
-    navigateToMyPageStressScore: () -> Unit,
+    navigateToMyPageStressScore: (String) -> Unit,
     navigateToMyPageAIFeedback: () -> Unit,
     viewModel: MyStressGraphViewModel = hiltViewModel()
 ) {
@@ -64,10 +64,19 @@ fun MyStressEmotionChangeGraphRoute(
 
     MyStressEmotionChangeGraphScreen(
         padding = padding,
+        date = date,
         weeklyStressScoreModel = weeklyStressScoreModel,
         weekOffset = weekOffset,
-        onPrevWeek = { weekOffset += 1 },
-        onNextWeek = { if (weekOffset > 0) weekOffset -= 1 },
+        onPrevWeekClick = { weekOffset += 1 },
+        onNextWeekClick = { if (weekOffset > 0) weekOffset -= 1 },
+        onBarClick = { index ->
+            val weekStart = LocalDate
+                .parse(weeklyStressScoreModel.startDate, DateTimeFormatter.ISO_LOCAL_DATE)
+            val barDate = weekStart
+                .plusDays(index.toLong())
+                .format(DateTimeFormatter.ISO_LOCAL_DATE)
+            navigateToMyPageStressScore(barDate)
+        },
         navigateToMyPageStressScore = navigateToMyPageStressScore,
         navigateToMyPageAIFeedback = navigateToMyPageAIFeedback
     )
@@ -76,11 +85,13 @@ fun MyStressEmotionChangeGraphRoute(
 @Composable
 private fun MyStressEmotionChangeGraphScreen(
     padding: PaddingValues,
+    date: String,
     weeklyStressScoreModel: WeeklyStressScoreModel,
     weekOffset: Int,
-    onPrevWeek: () -> Unit,
-    onNextWeek: () -> Unit,
-    navigateToMyPageStressScore: () -> Unit,
+    onPrevWeekClick: () -> Unit,
+    onNextWeekClick: () -> Unit,
+    onBarClick: (Int) -> Unit,
+    navigateToMyPageStressScore: (String) -> Unit,
     navigateToMyPageAIFeedback: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -118,7 +129,7 @@ private fun MyStressEmotionChangeGraphScreen(
                     painter = painterResource(R.drawable.ic_arrow_left),
                     contentDescription = stringResource(R.string.diary_calendar_month_left_arrow_description),
                     tint = colors.Gray300,
-                    modifier = Modifier.noRippleClickable { onPrevWeek() }
+                    modifier = Modifier.noRippleClickable { onPrevWeekClick() }
                 )
                 Text(
                     text = "${weekState.month}",
@@ -147,7 +158,7 @@ private fun MyStressEmotionChangeGraphScreen(
                     painter = painterResource(R.drawable.ic_arrow_right),
                     contentDescription = stringResource(R.string.diary_calendar_month_right_arrow_description),
                     tint = colors.Gray300,
-                    modifier = Modifier.noRippleClickable { onNextWeek() }
+                    modifier = Modifier.noRippleClickable { onNextWeekClick() }
                 )
             }
         }
@@ -178,8 +189,9 @@ private fun MyStressEmotionChangeGraphScreen(
 
         WeeklyBarChart(
             values = weeklyStressScoreModel.stressLevels,
+            onBarClick = onBarClick,
             modifier = Modifier.noRippleClickable {
-                navigateToMyPageStressScore()
+                navigateToMyPageStressScore(date)
             }
         )
 
@@ -194,6 +206,7 @@ private fun MyStressEmotionChangeGraphScreen(
 
         WeeklyBarChart(
             values = weeklyStressScoreModel.emotionLevels,
+            onBarClick = onBarClick,
             modifier = Modifier.noRippleClickable {
                 navigateToMyPageAIFeedback()
             }
@@ -207,6 +220,7 @@ private fun MyStressEmotionChangeGraphScreenPreview() {
     StrHatTheme {
         MyStressEmotionChangeGraphScreen(
             padding = PaddingValues(0.dp),
+            date = "2025-05-01",
             weeklyStressScoreModel = WeeklyStressScoreModel(
                 "",
                 "",
@@ -216,8 +230,9 @@ private fun MyStressEmotionChangeGraphScreenPreview() {
                 ""
             ),
             weekOffset = 1,
-            onPrevWeek = {},
-            onNextWeek = {},
+            onPrevWeekClick = {},
+            onNextWeekClick = {},
+            onBarClick = {},
             navigateToMyPageStressScore = {},
             navigateToMyPageAIFeedback = {}
         )

--- a/app/src/main/java/com/konkuk/strhat/feature/mypage/MyStressEmotionChangeGraphScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/mypage/MyStressEmotionChangeGraphScreen.kt
@@ -47,7 +47,7 @@ fun MyStressEmotionChangeGraphRoute(
     padding: PaddingValues,
     date: String,
     navigateToMyPageStressScore: (String) -> Unit,
-    navigateToMyPageAIFeedback: () -> Unit,
+    navigateToMyPageAIFeedback: (String) -> Unit,
     viewModel: MyStressGraphViewModel = hiltViewModel()
 ) {
     var weekOffset by remember { mutableIntStateOf(0) }
@@ -62,6 +62,20 @@ fun MyStressEmotionChangeGraphRoute(
 
     val weeklyStressScoreModel by viewModel.weeklyStressScoreModel.collectAsState()
 
+    val calculateBarDate: (Int) -> String = { index ->
+        LocalDate
+            .parse(weeklyStressScoreModel.startDate, DateTimeFormatter.ISO_LOCAL_DATE)
+            .plusDays(index.toLong())
+            .format(DateTimeFormatter.ISO_LOCAL_DATE)
+    }
+
+    val onStressBarClick = { index: Int ->
+        navigateToMyPageStressScore(calculateBarDate(index))
+    }
+    val onEmotionBarClick = { index: Int ->
+        navigateToMyPageAIFeedback(calculateBarDate(index))
+    }
+
     MyStressEmotionChangeGraphScreen(
         padding = padding,
         date = date,
@@ -69,14 +83,8 @@ fun MyStressEmotionChangeGraphRoute(
         weekOffset = weekOffset,
         onPrevWeekClick = { weekOffset += 1 },
         onNextWeekClick = { if (weekOffset > 0) weekOffset -= 1 },
-        onBarClick = { index ->
-            val weekStart = LocalDate
-                .parse(weeklyStressScoreModel.startDate, DateTimeFormatter.ISO_LOCAL_DATE)
-            val barDate = weekStart
-                .plusDays(index.toLong())
-                .format(DateTimeFormatter.ISO_LOCAL_DATE)
-            navigateToMyPageStressScore(barDate)
-        },
+        onStressBarClick = onStressBarClick,
+        onEmotionBarClick = onEmotionBarClick,
         navigateToMyPageStressScore = navigateToMyPageStressScore,
         navigateToMyPageAIFeedback = navigateToMyPageAIFeedback
     )
@@ -90,9 +98,10 @@ private fun MyStressEmotionChangeGraphScreen(
     weekOffset: Int,
     onPrevWeekClick: () -> Unit,
     onNextWeekClick: () -> Unit,
-    onBarClick: (Int) -> Unit,
+    onStressBarClick: (Int) -> Unit,
+    onEmotionBarClick: (Int) -> Unit,
     navigateToMyPageStressScore: (String) -> Unit,
-    navigateToMyPageAIFeedback: () -> Unit,
+    navigateToMyPageAIFeedback: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val weekState = getWeekStateFromOffset(weekOffset)
@@ -189,7 +198,7 @@ private fun MyStressEmotionChangeGraphScreen(
 
         WeeklyBarChart(
             values = weeklyStressScoreModel.stressLevels,
-            onBarClick = onBarClick,
+            onBarClick = onStressBarClick,
             modifier = Modifier.noRippleClickable {
                 navigateToMyPageStressScore(date)
             }
@@ -206,9 +215,9 @@ private fun MyStressEmotionChangeGraphScreen(
 
         WeeklyBarChart(
             values = weeklyStressScoreModel.emotionLevels,
-            onBarClick = onBarClick,
+            onBarClick = onEmotionBarClick,
             modifier = Modifier.noRippleClickable {
-                navigateToMyPageAIFeedback()
+                navigateToMyPageAIFeedback(date)
             }
         )
     }
@@ -232,7 +241,8 @@ private fun MyStressEmotionChangeGraphScreenPreview() {
             weekOffset = 1,
             onPrevWeekClick = {},
             onNextWeekClick = {},
-            onBarClick = {},
+            onStressBarClick = {},
+            onEmotionBarClick = {},
             navigateToMyPageStressScore = {},
             navigateToMyPageAIFeedback = {}
         )

--- a/app/src/main/java/com/konkuk/strhat/feature/mypage/MyStressEmotionChangeGraphScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/mypage/MyStressEmotionChangeGraphScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -33,24 +34,40 @@ import com.konkuk.strhat.core.component.SummaryBox
 import com.konkuk.strhat.core.component.section.PageDescriptionSection
 import com.konkuk.strhat.core.util.modifier.noRippleClickable
 import com.konkuk.strhat.core.util.time.getWeekStateFromOffset
+import com.konkuk.strhat.domain.entity.WeeklyStressScoreModel
 import com.konkuk.strhat.feature.mypage.component.WeeklyBarChart
-import com.konkuk.strhat.feature.mypage.state.MyWeeklyStressState
 import com.konkuk.strhat.ui.theme.StrHatTheme
 import com.konkuk.strhat.ui.theme.StrHatTheme.colors
 import com.konkuk.strhat.ui.theme.StrHatTheme.typography
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 @Composable
 fun MyStressEmotionChangeGraphRoute(
     padding: PaddingValues,
+    date: String,
     navigateToMyPageStressScore: () -> Unit,
     navigateToMyPageAIFeedback: () -> Unit,
-    viewModel: MyPageViewModel = hiltViewModel()
+    viewModel: MyStressGraphViewModel = hiltViewModel()
 ) {
-    val myWeeklyStressState by viewModel.myWeeklyStressState.collectAsState()
+    var weekOffset by remember { mutableIntStateOf(0) }
+    val initialDate = remember(date) { LocalDate.parse(date) }
+
+    LaunchedEffect(weekOffset) {
+        val targetDate = initialDate
+            .minusWeeks(weekOffset.toLong())
+            .format(DateTimeFormatter.ISO_LOCAL_DATE)
+        viewModel.getWeeklyStressScore(targetDate)
+    }
+
+    val weeklyStressScoreModel by viewModel.weeklyStressScoreModel.collectAsState()
 
     MyStressEmotionChangeGraphScreen(
         padding = padding,
-        myWeeklyStressState = myWeeklyStressState,
+        weeklyStressScoreModel = weeklyStressScoreModel,
+        weekOffset = weekOffset,
+        onPrevWeek = { weekOffset += 1 },
+        onNextWeek = { if (weekOffset > 0) weekOffset -= 1 },
         navigateToMyPageStressScore = navigateToMyPageStressScore,
         navigateToMyPageAIFeedback = navigateToMyPageAIFeedback
     )
@@ -59,12 +76,14 @@ fun MyStressEmotionChangeGraphRoute(
 @Composable
 private fun MyStressEmotionChangeGraphScreen(
     padding: PaddingValues,
-    myWeeklyStressState: MyWeeklyStressState,
+    weeklyStressScoreModel: WeeklyStressScoreModel,
+    weekOffset: Int,
+    onPrevWeek: () -> Unit,
+    onNextWeek: () -> Unit,
     navigateToMyPageStressScore: () -> Unit,
     navigateToMyPageAIFeedback: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    var weekOffset by remember { mutableIntStateOf(0) }
     val weekState = getWeekStateFromOffset(weekOffset)
 
     Column(
@@ -81,7 +100,7 @@ private fun MyStressEmotionChangeGraphScreen(
         ) {
             Row {
                 Text(
-                    text = myWeeklyStressState.nickname,
+                    text = weeklyStressScoreModel.nickname,
                     style = typography.head1_b_24,
                     color = colors.MainBlue
                 )
@@ -99,9 +118,7 @@ private fun MyStressEmotionChangeGraphScreen(
                     painter = painterResource(R.drawable.ic_arrow_left),
                     contentDescription = stringResource(R.string.diary_calendar_month_left_arrow_description),
                     tint = colors.Gray300,
-                    modifier = Modifier.noRippleClickable {
-                        weekOffset += 1
-                    }
+                    modifier = Modifier.noRippleClickable { onPrevWeek() }
                 )
                 Text(
                     text = "${weekState.month}",
@@ -130,9 +147,7 @@ private fun MyStressEmotionChangeGraphScreen(
                     painter = painterResource(R.drawable.ic_arrow_right),
                     contentDescription = stringResource(R.string.diary_calendar_month_right_arrow_description),
                     tint = colors.Gray300,
-                    modifier = Modifier.noRippleClickable {
-                        if (weekOffset > 0) weekOffset -= 1
-                    }
+                    modifier = Modifier.noRippleClickable { onNextWeek() }
                 )
             }
         }
@@ -148,7 +163,7 @@ private fun MyStressEmotionChangeGraphScreen(
         Spacer(modifier = Modifier.height(16.dp))
         
         SummaryBox(
-            summary = myWeeklyStressState.weeklySummary,
+            summary = weeklyStressScoreModel.weeklySummary,
             backgroundColor = colors.SubBlue
         )
 
@@ -162,7 +177,7 @@ private fun MyStressEmotionChangeGraphScreen(
         Spacer(modifier = Modifier.height(16.dp))
 
         WeeklyBarChart(
-            values = myWeeklyStressState.weeklyStressScores,
+            values = weeklyStressScoreModel.stressLevels,
             modifier = Modifier.noRippleClickable {
                 navigateToMyPageStressScore()
             }
@@ -178,7 +193,7 @@ private fun MyStressEmotionChangeGraphScreen(
         Spacer(modifier = Modifier.height(16.dp))
 
         WeeklyBarChart(
-            values = myWeeklyStressState.weeklyEmotionScores,
+            values = weeklyStressScoreModel.emotionLevels,
             modifier = Modifier.noRippleClickable {
                 navigateToMyPageAIFeedback()
             }
@@ -190,13 +205,19 @@ private fun MyStressEmotionChangeGraphScreen(
 @Composable
 private fun MyStressEmotionChangeGraphScreenPreview() {
     StrHatTheme {
-        val myWeeklyStressExampleState = MyWeeklyStressState(
-            nickname = "송민서",
-            weeklySummary = "사용자는 완벽주의적이고 내성적인 성향을 가지고 있어서 발표나 의견 충돌, 야근, 인적 손실, 신체적 피로, 그리고 가족 관련 걱정 등 다양한 요인들이 스트레스를 유발했을 것으로 판단됩니다. 이러한 스트레스 요인들이 하나씩 쌓이며 사용자의 마음과 몸에 부담을 주었을 것입니다. 스트레스 관리를 위해 업무에서 완벽을 추구하는 것보다 실수를 수용하고 동료와 의견을 잘 조율하며, 일과 휴식을 균형 있게 유지하는 것이 중요해 보입니다."
-        )
         MyStressEmotionChangeGraphScreen(
             padding = PaddingValues(0.dp),
-            myWeeklyStressState = myWeeklyStressExampleState,
+            weeklyStressScoreModel = WeeklyStressScoreModel(
+                "",
+                "",
+                emptyList(),
+                emptyList(),
+                "",
+                ""
+            ),
+            weekOffset = 1,
+            onPrevWeek = {},
+            onNextWeek = {},
             navigateToMyPageStressScore = {},
             navigateToMyPageAIFeedback = {}
         )

--- a/app/src/main/java/com/konkuk/strhat/feature/mypage/MyStressGraphViewModel.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/mypage/MyStressGraphViewModel.kt
@@ -1,0 +1,54 @@
+package com.konkuk.strhat.feature.mypage
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.konkuk.strhat.domain.entity.WeeklyStressScoreModel
+import com.konkuk.strhat.domain.repository.StressScoreRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import retrofit2.HttpException
+import timber.log.Timber
+import javax.inject.Inject
+
+@HiltViewModel
+class MyStressGraphViewModel @Inject constructor(
+    private val stressScoreRepository: StressScoreRepository
+) : ViewModel() {
+    private val _weeklyStressScoreModel = MutableStateFlow(WeeklyStressScoreModel("", "", emptyList(), emptyList(), "", ""))
+    val weeklyStressScoreModel = _weeklyStressScoreModel.asStateFlow()
+
+    fun getWeeklyStressScore(
+        date: String
+    ) {
+        viewModelScope.launch {
+            try {
+                stressScoreRepository.getWeeklyStressScore(date)
+                    .onSuccess { data ->
+                        _weeklyStressScoreModel.update {
+                            WeeklyStressScoreModel(
+                                nickname = data.nickname,
+                                weeklySummary = data.weeklySummary,
+                                stressLevels = data.stressLevels,
+                                emotionLevels = data.emotionLevels,
+                                startDate = data.startDate,
+                                endDate = data.endDate
+                            )
+                        }
+                    }
+                    .onFailure {
+                        if (it is HttpException) {
+                            val errorBody = it.response()?.errorBody()?.string()
+                            Timber.tag("get weekly stress score").e("$errorBody")
+                        } else {
+                            Timber.tag("get weekly stress score").e(it, "주간 스트레스 변화 시각화 조회 실패")
+                        }
+                    }
+            } catch (e: Exception) {
+                Timber.tag("get weekly stress score").e("주간 스트레스 변화 시각화 조회 서버 통신 오류")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/konkuk/strhat/feature/mypage/MyStressGraphViewModel.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/mypage/MyStressGraphViewModel.kt
@@ -38,12 +38,24 @@ class MyStressGraphViewModel @Inject constructor(
                             )
                         }
                     }
-                    .onFailure {
-                        if (it is HttpException) {
-                            val errorBody = it.response()?.errorBody()?.string()
-                            Timber.tag("get weekly stress score").e("$errorBody")
-                        } else {
-                            Timber.tag("get weekly stress score").e(it, "주간 스트레스 변화 시각화 조회 실패")
+                    .onFailure { throwable ->
+                        when {
+                            throwable is HttpException && throwable.code() == 404 -> {
+                                _weeklyStressScoreModel.update {
+                                    it.copy(
+                                        weeklySummary = "해당 기간에는 일기를 작성하지 않았습니다.",
+                                        stressLevels = emptyList(),
+                                        emotionLevels = emptyList()
+                                    )
+                                }
+                            }
+                            throwable is HttpException -> {
+                                val errorBody = throwable.response()?.errorBody()?.string()
+                                Timber.tag("get weekly stress score").e("$errorBody")
+                            }
+                            else -> {
+                                Timber.tag("get weekly stress score").e(throwable, "주간 스트레스 변화 시각화 조회 실패")
+                            }
                         }
                     }
             } catch (e: Exception) {

--- a/app/src/main/java/com/konkuk/strhat/feature/mypage/MyStressGraphViewModel.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/mypage/MyStressGraphViewModel.kt
@@ -2,6 +2,7 @@ package com.konkuk.strhat.feature.mypage
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.konkuk.strhat.core.util.KeyStorage.WEEKLY_DIARY_NOT_FOUND
 import com.konkuk.strhat.domain.entity.WeeklyStressScoreModel
 import com.konkuk.strhat.domain.repository.StressScoreRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -40,7 +41,7 @@ class MyStressGraphViewModel @Inject constructor(
                     }
                     .onFailure { throwable ->
                         when {
-                            throwable is HttpException && throwable.code() == 404 -> {
+                            throwable is HttpException && throwable.code() == WEEKLY_DIARY_NOT_FOUND -> {
                                 _weeklyStressScoreModel.update {
                                     it.copy(
                                         weeklySummary = "해당 기간에는 일기를 작성하지 않았습니다.",

--- a/app/src/main/java/com/konkuk/strhat/feature/mypage/component/TodayStressScoreEmptyView.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/mypage/component/TodayStressScoreEmptyView.kt
@@ -50,7 +50,7 @@ fun TodayStressScoreEmptyView(
             )
             Spacer(modifier = Modifier.height(30.dp))
             Text(
-                text = "해당 날짜에는\n스트레스 점수가 존재하지 않습니다.\n\n오늘의 일기를 작성하고 확인하러 와주세요!",
+                text = stringResource(R.string.stress_score_empty_view_description),
                 style = typography.body1_m_16,
                 color = colors.Gray500,
                 textAlign = TextAlign.Center

--- a/app/src/main/java/com/konkuk/strhat/feature/mypage/component/TodayStressScoreEmptyView.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/mypage/component/TodayStressScoreEmptyView.kt
@@ -1,0 +1,78 @@
+package com.konkuk.strhat.feature.mypage.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.konkuk.strhat.R
+import com.konkuk.strhat.core.component.button.StrHatButton
+import com.konkuk.strhat.ui.theme.StrHatTheme
+import com.konkuk.strhat.ui.theme.StrHatTheme.colors
+import com.konkuk.strhat.ui.theme.StrHatTheme.typography
+
+@Composable
+fun TodayStressScoreEmptyView(
+    modifier: Modifier = Modifier,
+    popBackStack: () -> Unit
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(colors.MainWhite)
+            .padding(horizontal = 20.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Column(
+            modifier = Modifier
+                .weight(1f),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Image(
+                painter = painterResource(R.drawable.ic_strhat_gray_shadow),
+                contentDescription = null,
+                modifier = Modifier
+                    .width(100.dp)
+            )
+            Spacer(modifier = Modifier.height(30.dp))
+            Text(
+                text = "해당 날짜에는\n스트레스 점수가 존재하지 않습니다.\n\n오늘의 일기를 작성하고 확인하러 와주세요!",
+                style = typography.body1_m_16,
+                color = colors.Gray500,
+                textAlign = TextAlign.Center
+            )
+        }
+
+        StrHatButton(
+            text = stringResource(R.string.my_page_go_back_button),
+            onClick = {
+                popBackStack()
+            },
+            modifier = Modifier.padding(bottom = 20.dp)
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun TodayStressScoreEmptyViewPreview() {
+    StrHatTheme {
+        TodayStressScoreEmptyView(
+            popBackStack = {}
+        )
+    }
+}

--- a/app/src/main/java/com/konkuk/strhat/feature/mypage/component/WeeklyBarChart.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/mypage/component/WeeklyBarChart.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.konkuk.strhat.core.util.modifier.noRippleClickable
 import com.konkuk.strhat.domain.type.DayOfWeekType
 import com.konkuk.strhat.ui.theme.StrHatTheme.colors
 import com.konkuk.strhat.ui.theme.StrHatTheme.typography
@@ -32,6 +33,7 @@ import com.konkuk.strhat.ui.theme.StrHatTheme.typography
 fun WeeklyBarChart(
     values: List<Int?>,
     maxBarHeight: Int = 200,
+    onBarClick: (Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val maxValue = values.filterNotNull().maxOrNull()?.toFloat() ?: 0f
@@ -60,7 +62,8 @@ fun WeeklyBarChart(
                     Box(
                         modifier = Modifier
                             .height(maxBarHeight.dp)
-                            .width(24.dp),
+                            .width(24.dp)
+                            .noRippleClickable { onBarClick(index) },
                         contentAlignment = Alignment.BottomCenter
                     ) {
                         Box(
@@ -119,5 +122,8 @@ fun WeeklyBarChart(
 @Composable
 fun WeeklyBarChartPreview() {
     val testValues = listOf(10, 2, 3, 4, 6, 7, 9)
-    WeeklyBarChart(values = testValues)
+    WeeklyBarChart(
+        values = testValues,
+        onBarClick = {}
+    )
 }

--- a/app/src/main/java/com/konkuk/strhat/feature/mypage/component/WeeklyBarChart.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/mypage/component/WeeklyBarChart.kt
@@ -30,11 +30,11 @@ import com.konkuk.strhat.ui.theme.StrHatTheme.typography
 
 @Composable
 fun WeeklyBarChart(
-    values: List<Int>,
+    values: List<Int?>,
     maxBarHeight: Int = 200,
     modifier: Modifier = Modifier
 ) {
-    val maxValue = values.maxOrNull()?.toFloat() ?: 0f
+    val maxValue = values.filterNotNull().maxOrNull()?.toFloat() ?: 0f
 
     Column(
         modifier = modifier
@@ -51,7 +51,7 @@ fun WeeklyBarChart(
             verticalAlignment = Alignment.Bottom
         ) {
             values.forEachIndexed { index, value ->
-                val ratio = if (maxValue > 0) value / maxValue else 0f
+                val ratio = if (maxValue > 0) (value?.toFloat() ?: 0f) / maxValue else 0f
 
                 Column(
                     modifier = Modifier,

--- a/app/src/main/java/com/konkuk/strhat/feature/mypage/navigation/MyPageNavigation.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/mypage/navigation/MyPageNavigation.kt
@@ -51,8 +51,8 @@ fun NavController.navigateToChangeGraph(date: String) {
     navigate(MyPageRoute.MyStressEmotionChangeGraph(date))
 }
 
-fun NavController.navigateToMyPageStressScore() {
-    navigate(MyPageRoute.MyPageStressScore)
+fun NavController.navigateToMyPageStressScore(date: String) {
+    navigate(MyPageRoute.MyPageStressScore(date))
 }
 
 fun NavController.navigateToMyPageChatHistory(diaryId: Int) {
@@ -66,7 +66,7 @@ fun NavGraphBuilder.myPageNavGraph(
     onNavigateToMySelfDiagnosisRecordResult: () -> Unit,
     onNavigateToChangeGraph: (String) -> Unit,
     onPopBackStack: () -> Unit,
-    onNavigateToMyPageStressScore: () -> Unit,
+    onNavigateToMyPageStressScore: (String) -> Unit,
     onNavigateToMyPageAIFeedback: () -> Unit,
     navController: NavController
 ) {
@@ -136,9 +136,12 @@ fun NavGraphBuilder.myPageNavGraph(
         )
     }
 
-    composable<MyPageRoute.MyPageStressScore> {
+    composable<MyPageRoute.MyPageStressScore> { navBackStackEntry ->
+        val date = navBackStackEntry.toRoute<MyPageRoute.MyPageStressScore>().date
+
         MyPageStressScoreRoute(
             padding = padding,
+            date = date,
             popBackStack = onPopBackStack
         )
     }

--- a/app/src/main/java/com/konkuk/strhat/feature/mypage/navigation/MyPageNavigation.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/mypage/navigation/MyPageNavigation.kt
@@ -67,7 +67,7 @@ fun NavGraphBuilder.myPageNavGraph(
     onNavigateToChangeGraph: (String) -> Unit,
     onPopBackStack: () -> Unit,
     onNavigateToMyPageStressScore: (String) -> Unit,
-    onNavigateToMyPageAIFeedback: () -> Unit,
+    onNavigateToMyPageAIFeedback: (String) -> Unit,
     navController: NavController
 ) {
     composable<MainTabRoute.MyPage> {

--- a/app/src/main/java/com/konkuk/strhat/feature/mypage/navigation/MyPageNavigation.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/mypage/navigation/MyPageNavigation.kt
@@ -47,8 +47,8 @@ fun NavController.navigateToMySelfDiagnosisRecordResult() {
     navigate(MyPageRoute.MySelfDiagnosisRecordResult)
 }
 
-fun NavController.navigateToChangeGraph() {
-    navigate(MyPageRoute.MyStressEmotionChangeGraph)
+fun NavController.navigateToChangeGraph(date: String) {
+    navigate(MyPageRoute.MyStressEmotionChangeGraph(date))
 }
 
 fun NavController.navigateToMyPageStressScore() {
@@ -64,7 +64,7 @@ fun NavGraphBuilder.myPageNavGraph(
     onNavigateToMyPage: () -> Unit,
     onNavigateToMySelfDiagnosisRecord: () -> Unit,
     onNavigateToMySelfDiagnosisRecordResult: () -> Unit,
-    onNavigateToChangeGraph: () -> Unit,
+    onNavigateToChangeGraph: (String) -> Unit,
     onPopBackStack: () -> Unit,
     onNavigateToMyPageStressScore: () -> Unit,
     onNavigateToMyPageAIFeedback: () -> Unit,
@@ -125,9 +125,12 @@ fun NavGraphBuilder.myPageNavGraph(
         )
     }
 
-    composable<MyPageRoute.MyStressEmotionChangeGraph> {
+    composable<MyPageRoute.MyStressEmotionChangeGraph> { navBackStackEntry ->
+        val date = navBackStackEntry.toRoute<MyPageRoute.MyStressEmotionChangeGraph>().date
+
         MyStressEmotionChangeGraphRoute(
             padding = padding,
+            date = date,
             navigateToMyPageStressScore = onNavigateToMyPageStressScore,
             navigateToMyPageAIFeedback = onNavigateToMyPageAIFeedback
         )

--- a/app/src/main/java/com/konkuk/strhat/feature/selfdiagnosis/SelfDiagnosisResultScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/selfdiagnosis/SelfDiagnosisResultScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -21,6 +22,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.konkuk.strhat.R
 import com.konkuk.strhat.core.component.button.StrHatButton
+import com.konkuk.strhat.domain.entity.SelfDiagnosisResultModel
 import com.konkuk.strhat.feature.selfdiagnosis.state.SelfDiagnosisResultState
 import com.konkuk.strhat.ui.theme.StrHatTheme
 import com.konkuk.strhat.ui.theme.StrHatTheme.colors
@@ -33,9 +35,15 @@ fun SelfDiagnosisResultRoute(
     viewModel: SelfDiagnosisViewModel = hiltViewModel()
 ) {
     val selfDiagnosisResultState by viewModel.selfDiagnosisResultState.collectAsState()
+    val selfDiagnosisRecordResultModel by viewModel.selfDiagnosisResultModel.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.getSelfDiagnosisResult("2025-05-14", "phq9")  // type도 넘겨받은 걸로 해야 함
+    }
 
     SelfDiagnosisResultScreen(
         padding = padding,
+        selfDiagnosisRecordResultModel = selfDiagnosisRecordResultModel,
         selfDiagnosisResultState = selfDiagnosisResultState,
         navigateToSelfDiagnosis = navigateToSelfDiagnosis
     )
@@ -44,6 +52,7 @@ fun SelfDiagnosisResultRoute(
 @Composable
 fun SelfDiagnosisResultScreen(
     padding: PaddingValues,
+    selfDiagnosisRecordResultModel: SelfDiagnosisResultModel,
     selfDiagnosisResultState: SelfDiagnosisResultState,
     navigateToSelfDiagnosis: () -> Unit,
     modifier: Modifier = Modifier
@@ -60,7 +69,7 @@ fun SelfDiagnosisResultScreen(
         ) {
             Row {
                 Text(
-                    text = selfDiagnosisResultState.nickname,
+                    text = selfDiagnosisRecordResultModel.nickname,
                     style = typography.head1_b_24,
                     color = colors.MainBlue
                 )
@@ -74,12 +83,14 @@ fun SelfDiagnosisResultScreen(
             Spacer(modifier = Modifier.height(8.dp))
             
             Row {
-                Text(
-                    text = selfDiagnosisResultState.testType,
-                    style = typography.head0_b_26,
-                    color = colors.MainBlack,
-                    modifier = Modifier.align(Alignment.CenterVertically)
-                )
+                selfDiagnosisRecordResultModel.type?.let {
+                    Text(
+                        text = it,
+                        style = typography.head0_b_26,
+                        color = colors.MainBlack,
+                        modifier = Modifier.align(Alignment.CenterVertically)
+                    )
+                }
 
                 Spacer(modifier = Modifier.width(4.dp))
 
@@ -98,7 +109,7 @@ fun SelfDiagnosisResultScreen(
 
             Row {
                 Text(
-                    text = selfDiagnosisResultState.stressScore.toString(),
+                    text = selfDiagnosisRecordResultModel.score.toString(),
                     style = typography.head0_b_26,
                     color = colors.MainBlue,
                     modifier = Modifier.align(Alignment.CenterVertically)
@@ -116,11 +127,13 @@ fun SelfDiagnosisResultScreen(
             Spacer(modifier = Modifier.height(30.dp))
 
             Row {
-                Text(
-                    text = selfDiagnosisResultState.stressLevel,
-                    style = typography.head2_b_20,
-                    color = colors.MainBlue
-                )
+                selfDiagnosisRecordResultModel.selfDiagnosisLevel?.let {
+                    Text(
+                        text = it,
+                        style = typography.head2_b_20,
+                        color = colors.MainBlue
+                    )
+                }
                 Text(
                     text = stringResource(R.string.self_diagnosis_result_stress_level_end),
                     style = typography.head2_r_20,
@@ -172,6 +185,7 @@ fun SelfDiagnosisResultScreenPreview() {
 
         SelfDiagnosisResultScreen(
             padding = PaddingValues(),
+            selfDiagnosisRecordResultModel = SelfDiagnosisResultModel("", 1, "", ""),
             selfDiagnosisResultState = selfDiagnosisResultExampleState,
             navigateToSelfDiagnosis = {}
         )

--- a/app/src/main/java/com/konkuk/strhat/feature/selfdiagnosis/SelfDiagnosisResultScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/selfdiagnosis/SelfDiagnosisResultScreen.kt
@@ -27,18 +27,23 @@ import com.konkuk.strhat.feature.selfdiagnosis.state.SelfDiagnosisResultState
 import com.konkuk.strhat.ui.theme.StrHatTheme
 import com.konkuk.strhat.ui.theme.StrHatTheme.colors
 import com.konkuk.strhat.ui.theme.StrHatTheme.typography
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 @Composable
 fun SelfDiagnosisResultRoute(
     padding: PaddingValues,
+    type: String,
     navigateToSelfDiagnosis: () -> Unit,
     viewModel: SelfDiagnosisViewModel = hiltViewModel()
 ) {
     val selfDiagnosisResultState by viewModel.selfDiagnosisResultState.collectAsState()
     val selfDiagnosisRecordResultModel by viewModel.selfDiagnosisResultModel.collectAsState()
 
+    val date = LocalDate.now().format(DateTimeFormatter.ISO_DATE)
+
     LaunchedEffect(Unit) {
-        viewModel.getSelfDiagnosisResult("2025-05-14", "phq9")  // type도 넘겨받은 걸로 해야 함
+        viewModel.getSelfDiagnosisResult(date, type)
     }
 
     SelfDiagnosisResultScreen(

--- a/app/src/main/java/com/konkuk/strhat/feature/selfdiagnosis/SelfDiagnosisScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/selfdiagnosis/SelfDiagnosisScreen.kt
@@ -100,7 +100,7 @@ private fun SelfDiagnosisScreen(
 
         StrHatButton(
             text = stringResource(R.string.self_diagnosis_PHQ_9_button),
-            onClick = { onTestBtnClick("phq-9") }
+            onClick = { onTestBtnClick("phq9") }
         )
     }
 }

--- a/app/src/main/java/com/konkuk/strhat/feature/selfdiagnosis/SelfDiagnosisScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/selfdiagnosis/SelfDiagnosisScreen.kt
@@ -23,7 +23,7 @@ import com.konkuk.strhat.ui.theme.StrHatTheme.typography
 @Composable
 fun SelfDiagnosisRoute(
     padding: PaddingValues,
-    navigateToSelfDiagnosisTest: () -> Unit,
+    navigateToSelfDiagnosisTest: (String) -> Unit,
     viewModel: SelfDiagnosisViewModel = hiltViewModel()
 ) {
     SelfDiagnosisScreen(
@@ -35,7 +35,7 @@ fun SelfDiagnosisRoute(
 @Composable
 private fun SelfDiagnosisScreen(
     padding: PaddingValues,
-    onTestBtnClick: () -> Unit,
+    onTestBtnClick: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -62,7 +62,7 @@ private fun SelfDiagnosisScreen(
 
         StrHatButton(
             text = stringResource(R.string.self_diagnosis_PSS_button),
-            onClick = { onTestBtnClick() }
+            onClick = { onTestBtnClick("pss") }
         )
 
         Spacer(modifier = Modifier.height(16.dp))
@@ -77,7 +77,7 @@ private fun SelfDiagnosisScreen(
 
         StrHatButton(
             text = stringResource(R.string.self_diagnosis_SRI_button),
-            onClick = { onTestBtnClick() }
+            onClick = { onTestBtnClick("sri") }
         )
 
         Spacer(modifier = Modifier.height(36.dp))
@@ -100,7 +100,7 @@ private fun SelfDiagnosisScreen(
 
         StrHatButton(
             text = stringResource(R.string.self_diagnosis_PHQ_9_button),
-            onClick = { onTestBtnClick() }
+            onClick = { onTestBtnClick("phq-9") }
         )
     }
 }

--- a/app/src/main/java/com/konkuk/strhat/feature/selfdiagnosis/SelfDiagnosisTestScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/selfdiagnosis/SelfDiagnosisTestScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.konkuk.strhat.core.component.button.StrHatButton
 import com.konkuk.strhat.domain.entity.SelfDiagnosisItem
+import com.konkuk.strhat.domain.entity.SelfDiagnosisModel
 import com.konkuk.strhat.ui.theme.StrHatTheme
 import com.konkuk.strhat.ui.theme.StrHatTheme.colors
 import com.konkuk.strhat.ui.theme.StrHatTheme.typography
@@ -37,7 +38,7 @@ fun SelfDiagnosisTestRoute(
     navigateToSelfDiagnosisResult: () -> Unit,
     viewModel: SelfDiagnosisViewModel = hiltViewModel()
 ) {
-    val questions by viewModel.selfDiagnosisModel.collectAsState()
+    val questions by viewModel.selfDiagnosisListModel.collectAsState()
 
     LaunchedEffect(Unit) {
         viewModel.getSelfDiagnosisQuestionList(type)
@@ -48,7 +49,16 @@ fun SelfDiagnosisTestRoute(
     SelfDiagnosisTestScreen(
         padding = padding,
         type = type,
-        navigateToSelfDiagnosisResult = navigateToSelfDiagnosisResult,
+        navigateToSelfDiagnosisResult = {
+            val totalScore = selectedScores.values.sum()
+            val selfDiagnosis = SelfDiagnosisModel(
+                type = type,
+                selfDiagnosisScore = totalScore
+            )
+            viewModel.postSelfDiagnosis(selfDiagnosis)
+
+            navigateToSelfDiagnosisResult()
+        },
         questions = questions,
         onSelectionChanged = { index, score ->
             selectedScores[index] = score

--- a/app/src/main/java/com/konkuk/strhat/feature/selfdiagnosis/SelfDiagnosisTestScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/selfdiagnosis/SelfDiagnosisTestScreen.kt
@@ -1,48 +1,142 @@
 package com.konkuk.strhat.feature.selfdiagnosis
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.RadioButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import com.konkuk.strhat.R
-import com.konkuk.strhat.core.util.modifier.noRippleClickable
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.konkuk.strhat.core.component.button.StrHatButton
+import com.konkuk.strhat.domain.entity.SelfDiagnosisItem
 import com.konkuk.strhat.ui.theme.StrHatTheme
 import com.konkuk.strhat.ui.theme.StrHatTheme.colors
+import com.konkuk.strhat.ui.theme.StrHatTheme.typography
 
 @Composable
 fun SelfDiagnosisTestRoute(
     padding: PaddingValues,
-    navigateToSelfDiagnosisResult: () -> Unit
+    type: String,
+    navigateToSelfDiagnosisResult: () -> Unit,
+    viewModel: SelfDiagnosisViewModel = hiltViewModel()
 ) {
+    val questions by viewModel.selfDiagnosisModel.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.getSelfDiagnosisQuestionList(type)
+    }
+
+    val selectedScores = remember { mutableStateMapOf<Int, Int>() }
+
     SelfDiagnosisTestScreen(
         padding = padding,
-        navigateToSelfDiagnosisResult = navigateToSelfDiagnosisResult
+        type = type,
+        navigateToSelfDiagnosisResult = navigateToSelfDiagnosisResult,
+        questions = questions,
+        onSelectionChanged = { index, score ->
+            selectedScores[index] = score
+        }
     )
 }
 
 @Composable
 fun SelfDiagnosisTestScreen(
     padding: PaddingValues,
+    type: String,
     navigateToSelfDiagnosisResult: () -> Unit,
+    questions: List<SelfDiagnosisItem>,
+    onSelectionChanged: (index: Int, score: Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
+
+    val selections = remember { mutableStateMapOf<Int, Int>() }
+
+    val selfDiagnosisTestScreenTitle = when (type) {
+        "pss" -> "스틀햇과 함께 하는 PSS 검사"
+        "sri" -> "스틀햇과 함께 하는 SRI 검사"
+        "phq-9" -> "스틀햇과 함께 하는 PHQ-9 검사"
+        else -> "스틀햇과 함께 하는 자가진단 검사"
+    }
+
     Column(
-        modifier = modifier
+        modifier = modifier.padding(16.dp)
             .fillMaxSize()
-            .background(colors.MainWhite),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally
     ) {
+        Spacer(modifier = Modifier.height(16.dp))
         Text(
-            text = stringResource(R.string.self_diagnosis_test_screen_title),
-            modifier = Modifier.noRippleClickable {
+            text = selfDiagnosisTestScreenTitle,
+            style = typography.head1_b_24
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = "1 : 전혀 그렇지 않다, 2 : 그렇지 않다, 3 : 보통이다,\n\n4 : 그렇다, 5 : 매우 그렇다",
+            style = typography.body3_m_14
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+
+        LazyColumn(
+            modifier = Modifier
+                .weight(1f),
+            verticalArrangement = Arrangement.spacedBy(24.dp)
+        ) {
+            items(questions) { item ->
+                Column(
+                    modifier = Modifier.padding(top = 20.dp)
+                ) {
+                    Text(
+                        text = "${item.selfDiagnosisIndex}. ${item.selfDiagnosisQuestion}",
+                        style = typography.body1_m_16,
+                        modifier = Modifier.padding(bottom = 12.dp)
+                    )
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        (1..5).forEach { score ->
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                RadioButton(
+                                    selected = selections[item.selfDiagnosisIndex] == score,
+                                    onClick = {
+                                        selections[item.selfDiagnosisIndex] = score
+                                        onSelectionChanged(item.selfDiagnosisIndex, score)
+                                    },
+                                    colors = RadioButtonDefaults.colors(
+                                        selectedColor = colors.MainBlue,
+                                        unselectedColor = colors.Gray500
+                                    )
+                                )
+                                Text(text = score.toString())
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        StrHatButton(
+            text = "검사 종료하기",
+            onClick = {
                 navigateToSelfDiagnosisResult()
             }
         )
@@ -55,7 +149,10 @@ fun SelfDiagnosisTestScreenPreview() {
     StrHatTheme {
         SelfDiagnosisTestScreen(
             padding = PaddingValues(),
-            navigateToSelfDiagnosisResult = {}
+            type = "pss",
+            navigateToSelfDiagnosisResult = {},
+            questions = emptyList(),
+            onSelectionChanged = { _, _ -> }
         )
     }
 }

--- a/app/src/main/java/com/konkuk/strhat/feature/selfdiagnosis/SelfDiagnosisTestScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/selfdiagnosis/SelfDiagnosisTestScreen.kt
@@ -71,7 +71,7 @@ fun SelfDiagnosisTestScreen(
     val selfDiagnosisTestScreenTitle = when (type) {
         "pss" -> "스틀햇과 함께 하는 PSS 검사"
         "sri" -> "스틀햇과 함께 하는 SRI 검사"
-        "phq-9" -> "스틀햇과 함께 하는 PHQ-9 검사"
+        "phq9" -> "스틀햇과 함께 하는 PHQ-9 검사"
         else -> "스틀햇과 함께 하는 자가진단 검사"
     }
 
@@ -86,8 +86,9 @@ fun SelfDiagnosisTestScreen(
         )
         Spacer(modifier = Modifier.height(16.dp))
         Text(
-            text = "1 : 전혀 그렇지 않다, 2 : 그렇지 않다, 3 : 보통이다,\n\n4 : 그렇다, 5 : 매우 그렇다",
-            style = typography.body3_m_14
+            text = "1 : 전혀 그렇지 않다, 2 : 그렇지 않다,\n\n3 : 보통이다, 4 : 그렇다, 5 : 매우 그렇다",
+            style = typography.body3_m_14,
+            color = colors.Gray400
         )
         Spacer(modifier = Modifier.height(16.dp))
 

--- a/app/src/main/java/com/konkuk/strhat/feature/selfdiagnosis/SelfDiagnosisTestScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/selfdiagnosis/SelfDiagnosisTestScreen.kt
@@ -21,12 +21,15 @@ import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.konkuk.strhat.R
 import com.konkuk.strhat.core.component.button.StrHatButton
 import com.konkuk.strhat.domain.entity.SelfDiagnosisItem
 import com.konkuk.strhat.domain.entity.SelfDiagnosisModel
+import com.konkuk.strhat.domain.type.SelfDiagnosisTestType
 import com.konkuk.strhat.ui.theme.StrHatTheme
 import com.konkuk.strhat.ui.theme.StrHatTheme.colors
 import com.konkuk.strhat.ui.theme.StrHatTheme.typography
@@ -79,10 +82,10 @@ fun SelfDiagnosisTestScreen(
     val selections = remember { mutableStateMapOf<Int, Int>() }
 
     val selfDiagnosisTestScreenTitle = when (type) {
-        "pss" -> "스틀햇과 함께 하는 PSS 검사"
-        "sri" -> "스틀햇과 함께 하는 SRI 검사"
-        "phq9" -> "스틀햇과 함께 하는 PHQ-9 검사"
-        else -> "스틀햇과 함께 하는 자가진단 검사"
+        SelfDiagnosisTestType.PSS.testType -> stringResource(R.string.self_diagnosis_test_PSS_title)
+        SelfDiagnosisTestType.SRI.testType -> stringResource(R.string.self_diagnosis_test_SRI_title)
+        SelfDiagnosisTestType.PHQ9.testType -> stringResource(R.string.self_diagnosis_test_PHQ_9_title)
+        else -> stringResource(R.string.self_diagnosis_test_default_title)
     }
 
     Column(
@@ -96,7 +99,7 @@ fun SelfDiagnosisTestScreen(
         )
         Spacer(modifier = Modifier.height(16.dp))
         Text(
-            text = "1 : 전혀 그렇지 않다, 2 : 그렇지 않다,\n\n3 : 보통이다, 4 : 그렇다, 5 : 매우 그렇다",
+            text = stringResource(R.string.self_diagnosis_test_selection_description),
             style = typography.body3_m_14,
             color = colors.Gray400
         )
@@ -146,7 +149,7 @@ fun SelfDiagnosisTestScreen(
         Spacer(modifier = Modifier.height(16.dp))
 
         StrHatButton(
-            text = "검사 종료하기",
+            text = stringResource(R.string.self_diagnosis_test_exit_button),
             onClick = {
                 navigateToSelfDiagnosisResult()
             }

--- a/app/src/main/java/com/konkuk/strhat/feature/selfdiagnosis/SelfDiagnosisTestScreen.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/selfdiagnosis/SelfDiagnosisTestScreen.kt
@@ -35,7 +35,7 @@ import com.konkuk.strhat.ui.theme.StrHatTheme.typography
 fun SelfDiagnosisTestRoute(
     padding: PaddingValues,
     type: String,
-    navigateToSelfDiagnosisResult: () -> Unit,
+    navigateToSelfDiagnosisResult: (String) -> Unit,
     viewModel: SelfDiagnosisViewModel = hiltViewModel()
 ) {
     val questions by viewModel.selfDiagnosisListModel.collectAsState()
@@ -57,7 +57,7 @@ fun SelfDiagnosisTestRoute(
             )
             viewModel.postSelfDiagnosis(selfDiagnosis)
 
-            navigateToSelfDiagnosisResult()
+            navigateToSelfDiagnosisResult(type)
         },
         questions = questions,
         onSelectionChanged = { index, score ->

--- a/app/src/main/java/com/konkuk/strhat/feature/selfdiagnosis/SelfDiagnosisViewModel.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/selfdiagnosis/SelfDiagnosisViewModel.kt
@@ -3,6 +3,7 @@ package com.konkuk.strhat.feature.selfdiagnosis
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.konkuk.strhat.domain.entity.SelfDiagnosisItem
+import com.konkuk.strhat.domain.entity.SelfDiagnosisModel
 import com.konkuk.strhat.domain.entity.SelfDiagnosisResultModel
 import com.konkuk.strhat.domain.repository.SelfDiagnosisRepository
 import com.konkuk.strhat.feature.selfdiagnosis.state.SelfDiagnosisResultState
@@ -41,10 +42,13 @@ class SelfDiagnosisViewModel @Inject constructor(
     }
 
     private val _selfDiagnosisListModel = MutableStateFlow<List<SelfDiagnosisItem>>(emptyList())
-    val selfDiagnosisModel = _selfDiagnosisListModel.asStateFlow()
+    val selfDiagnosisListModel = _selfDiagnosisListModel.asStateFlow()
 
     private val _selfDiagnosisResultModel = MutableStateFlow(SelfDiagnosisResultModel("", 1, "", ""))
     val selfDiagnosisResultModel: StateFlow<SelfDiagnosisResultModel> = _selfDiagnosisResultModel
+
+    private val _selfDiagnosisModel = MutableStateFlow(SelfDiagnosisModel("", 1))
+    val selfDiagnosisModel: StateFlow<SelfDiagnosisModel> = _selfDiagnosisModel
 
     fun getSelfDiagnosisQuestionList(
         type: String
@@ -98,6 +102,29 @@ class SelfDiagnosisViewModel @Inject constructor(
                     }
             } catch (e: Exception) {
                 Timber.tag("get self diagnosis result").e("자가진단 문제 데이터 조회 서버 통신 오류")
+            }
+        }
+    }
+
+    fun postSelfDiagnosis(
+        request: SelfDiagnosisModel
+    ) {
+        viewModelScope.launch {
+            try {
+                selfDiagnosisRepository.postSelfDiagnosis(request)
+                    .onSuccess {
+
+                    }
+                    .onFailure {
+                        if (it is HttpException) {
+                            val errorBody = it.response()?.errorBody()?.string()
+                            Timber.tag("post self diagnosis").e("$errorBody")
+                        } else {
+                            Timber.tag("post self diagnosis").e(it, "자가진단 결과 저장 실패")
+                        }
+                    }
+            } catch (e: Exception) {
+                Timber.tag("post self diagnosis").e("자가진단 결과 저장 서버 통신 오류")
             }
         }
     }

--- a/app/src/main/java/com/konkuk/strhat/feature/selfdiagnosis/SelfDiagnosisViewModel.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/selfdiagnosis/SelfDiagnosisViewModel.kt
@@ -3,10 +3,12 @@ package com.konkuk.strhat.feature.selfdiagnosis
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.konkuk.strhat.domain.entity.SelfDiagnosisItem
+import com.konkuk.strhat.domain.entity.SelfDiagnosisResultModel
 import com.konkuk.strhat.domain.repository.SelfDiagnosisRepository
 import com.konkuk.strhat.feature.selfdiagnosis.state.SelfDiagnosisResultState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -41,6 +43,9 @@ class SelfDiagnosisViewModel @Inject constructor(
     private val _selfDiagnosisListModel = MutableStateFlow<List<SelfDiagnosisItem>>(emptyList())
     val selfDiagnosisModel = _selfDiagnosisListModel.asStateFlow()
 
+    private val _selfDiagnosisResultModel = MutableStateFlow(SelfDiagnosisResultModel("", 1, "", ""))
+    val selfDiagnosisResultModel: StateFlow<SelfDiagnosisResultModel> = _selfDiagnosisResultModel
+
     fun getSelfDiagnosisQuestionList(
         type: String
     ) {
@@ -62,6 +67,37 @@ class SelfDiagnosisViewModel @Inject constructor(
                     }
             } catch (e: Exception) {
                 Timber.tag("get self diagnosis question list").e("자가진단 문제 데이터 조회 서버 통신 오류")
+            }
+        }
+    }
+
+    fun getSelfDiagnosisResult(
+        date: String,
+        type: String
+    ) {
+        viewModelScope.launch {
+            try {
+                selfDiagnosisRepository.getSelfDiagnosisResult(date, type)
+                    .onSuccess { data ->
+                        _selfDiagnosisResultModel.update {
+                            SelfDiagnosisResultModel(
+                                nickname = data.nickname,
+                                score = data.score,
+                                type = data.type,
+                                selfDiagnosisLevel = data.selfDiagnosisLevel
+                            )
+                        }
+                    }
+                    .onFailure {
+                        if (it is HttpException) {
+                            val errorBody = it.response()?.errorBody()?.string()
+                            Timber.tag("get self diagnosis result").e("$errorBody")
+                        } else {
+                            Timber.tag("get self diagnosis result").e(it, "자가진단 결과 조회 실패")
+                        }
+                    }
+            } catch (e: Exception) {
+                Timber.tag("get self diagnosis result").e("자가진단 문제 데이터 조회 서버 통신 오류")
             }
         }
     }

--- a/app/src/main/java/com/konkuk/strhat/feature/selfdiagnosis/SelfDiagnosisViewModel.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/selfdiagnosis/SelfDiagnosisViewModel.kt
@@ -1,15 +1,23 @@
 package com.konkuk.strhat.feature.selfdiagnosis
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.konkuk.strhat.domain.entity.SelfDiagnosisItem
+import com.konkuk.strhat.domain.repository.SelfDiagnosisRepository
 import com.konkuk.strhat.feature.selfdiagnosis.state.SelfDiagnosisResultState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import retrofit2.HttpException
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
-class SelfDiagnosisViewModel @Inject constructor() : ViewModel() {
+class SelfDiagnosisViewModel @Inject constructor(
+    private val selfDiagnosisRepository: SelfDiagnosisRepository
+) : ViewModel() {
     private val _selfDiagnosisResultState = MutableStateFlow(SelfDiagnosisResultState())
     val selfDiagnosisResultState = _selfDiagnosisResultState.asStateFlow()
 
@@ -27,6 +35,34 @@ class SelfDiagnosisViewModel @Inject constructor() : ViewModel() {
                         "19점: 높은 스트레스 수준\n\n" + "이 척도는 Cohen, Kamarck과 Mermelstein (1983)의 지각된 스트레스 척도를 한국 실정에 맞게 번안하여 한국 대학생을 대상으로 타당화한 것입니다.\n" +
                         "한국심리학회 홈페이지 또는 KSI한국학술정보 홈페이지에서 원문을 보실 수 있습니다."
             )
+        }
+    }
+
+    private val _selfDiagnosisListModel = MutableStateFlow<List<SelfDiagnosisItem>>(emptyList())
+    val selfDiagnosisModel = _selfDiagnosisListModel.asStateFlow()
+
+    fun getSelfDiagnosisQuestionList(
+        type: String
+    ) {
+        viewModelScope.launch {
+            try {
+                selfDiagnosisRepository.getSelfDiagnosisQuestionList(type)
+                    .onSuccess { data ->
+                        _selfDiagnosisListModel.update {
+                            data
+                        }
+                    }
+                    .onFailure {
+                        if (it is HttpException) {
+                            val errorBody = it.response()?.errorBody()?.string()
+                            Timber.tag("get self diagnosis question list").e("$errorBody")
+                        } else {
+                            Timber.tag("get self diagnosis question list").e(it, "자가진단 문제 데이터 조회 실패")
+                        }
+                    }
+            } catch (e: Exception) {
+                Timber.tag("get self diagnosis question list").e("자가진단 문제 데이터 조회 서버 통신 오류")
+            }
         }
     }
 }

--- a/app/src/main/java/com/konkuk/strhat/feature/selfdiagnosis/navigation/SelfDiagnosisNavigation.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/selfdiagnosis/navigation/SelfDiagnosisNavigation.kt
@@ -20,14 +20,14 @@ fun NavController.navigateToSelfDiagnosisTest(type: String) {
     navigate(SelfDiagnosisRoute.SelfDiagnosisTest(type))
 }
 
-fun NavController.navigateToSelfDiagnosisResult() {
-    navigate(SelfDiagnosisRoute.SelfDiagnosisResult)
+fun NavController.navigateToSelfDiagnosisResult(type: String) {
+    navigate(SelfDiagnosisRoute.SelfDiagnosisResult(type))
 }
 
 fun NavGraphBuilder.selfDiagnosisNavGraph(
     padding: PaddingValues,
     onNavigateToSelfDiagnosisTest: (String) -> Unit,
-    onNavigateToSelfDiagnosisResult: () -> Unit,
+    onNavigateToSelfDiagnosisResult: (String) -> Unit,
     onNavigateToSelfDiagnosis: () -> Unit
 ) {
     composable<MainTabRoute.SelfDiagnosis> {
@@ -47,9 +47,12 @@ fun NavGraphBuilder.selfDiagnosisNavGraph(
         )
     }
 
-    composable<SelfDiagnosisRoute.SelfDiagnosisResult> {
+    composable<SelfDiagnosisRoute.SelfDiagnosisResult> { navBackStackEntry ->
+        val type = navBackStackEntry.toRoute<SelfDiagnosisRoute.SelfDiagnosisResult>().type
+
         SelfDiagnosisResultRoute(
             padding = padding,
+            type = type,
             navigateToSelfDiagnosis = onNavigateToSelfDiagnosis
         )
     }

--- a/app/src/main/java/com/konkuk/strhat/feature/selfdiagnosis/navigation/SelfDiagnosisNavigation.kt
+++ b/app/src/main/java/com/konkuk/strhat/feature/selfdiagnosis/navigation/SelfDiagnosisNavigation.kt
@@ -5,6 +5,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import androidx.navigation.toRoute
 import com.konkuk.strhat.core.navigation.MainTabRoute
 import com.konkuk.strhat.core.navigation.SelfDiagnosisRoute
 import com.konkuk.strhat.feature.selfdiagnosis.SelfDiagnosisResultRoute
@@ -15,8 +16,8 @@ fun NavController.navigateToSelfDiagnosis(navOptions: NavOptions) {
     navigate(MainTabRoute.SelfDiagnosis, navOptions)
 }
 
-fun NavController.navigateToSelfDiagnosisTest() {
-    navigate(SelfDiagnosisRoute.SelfDiagnosisTest)
+fun NavController.navigateToSelfDiagnosisTest(type: String) {
+    navigate(SelfDiagnosisRoute.SelfDiagnosisTest(type))
 }
 
 fun NavController.navigateToSelfDiagnosisResult() {
@@ -25,7 +26,7 @@ fun NavController.navigateToSelfDiagnosisResult() {
 
 fun NavGraphBuilder.selfDiagnosisNavGraph(
     padding: PaddingValues,
-    onNavigateToSelfDiagnosisTest: () -> Unit,
+    onNavigateToSelfDiagnosisTest: (String) -> Unit,
     onNavigateToSelfDiagnosisResult: () -> Unit,
     onNavigateToSelfDiagnosis: () -> Unit
 ) {
@@ -36,9 +37,12 @@ fun NavGraphBuilder.selfDiagnosisNavGraph(
         )
     }
 
-    composable<SelfDiagnosisRoute.SelfDiagnosisTest> {
+    composable<SelfDiagnosisRoute.SelfDiagnosisTest> { navBackStackEntry ->
+        val type = navBackStackEntry.toRoute<SelfDiagnosisRoute.SelfDiagnosisTest>().type
+
         SelfDiagnosisTestRoute(
             padding = padding,
+            type = type,
             navigateToSelfDiagnosisResult = onNavigateToSelfDiagnosisResult
         )
     }

--- a/app/src/main/java/com/konkuk/strhat/ui/theme/Type.kt
+++ b/app/src/main/java/com/konkuk/strhat/ui/theme/Type.kt
@@ -67,7 +67,7 @@ val defaultStrHatTypography = StrHatTypography(
     body1_m_16 = TextStyle(
         fontFamily = strHatFontMedium,
         fontSize = 16.sp,
-        lineHeight = 18.sp
+        lineHeight = 22.sp
     ),
     body1_r_16 = TextStyle(
         fontFamily = strHatFontRegular,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -123,7 +123,7 @@
     <string name="home_title">안녕하세요, %s님</string>
     <string name="home_keyword">오늘의 키워드는\n%s, %s, %s이었네요</string>
     <string name="home_image_description">오늘의 감정 이미지</string>
-    <string name="home_stress_title">오늘의 스트레스 점수는\n%d이에요</string>
+    <string name="home_stress_title">오늘의 스트레스 점수는\n%d 이에요</string>
     <string name="home_stress_sub_title">%s에 해당되네요</string>
     <string name="home_stress_description">스틀햇이 일기와 대화를 기반으로\n스트레스 점수를 평가했어요.\n1~5까지는 낮은 스트레스, 6~8까지는 보통 스트레스, 9~10까지는 높은 스트레스에요.</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -171,6 +171,7 @@
     <string name="stress_score_level_description">스틀햇이 일기와 대화를 기반으로\n스트레스 점수를 평가했어요.\n1~5까지는 낮은 스트레스, 6~8까지는 보통 스트레스, 9~10까지는 높은 스트레스에요.</string>
     <string name="stress_score_analysis_title">스트레스 원인 분석</string>
     <string name="stress_score_to_home">홈화면으로 돌아가기</string>
+    <string name="stress_score_empty_view_description">해당 날짜에는\n스트레스 점수가 존재하지 않습니다.\n\n오늘의 일기를 작성하고 확인하러 와주세요!</string>
 
     <!-- self diagnosis -->
     <string name="self_diagnosis_screen_stress_title">스트레스 자가 진단</string>
@@ -182,6 +183,14 @@
     <string name="self_diagnosis_description_PHQ_9">정확한 결과를 제공하기 위해 과학적으로 검증된 도구를 사용합니다.\n\n이 진단은 한국판 우울증 선별도구(Patient Health Questionnaire-9, PHQ-9)를 기반으로 한 전문적인 검사입니다.</string>
     <string name="self_diagnosis_PHQ_9_button">PHQ-9 검사하기</string>
     <string name="self_diagnosis_test_screen_title">자가 진단 문제지 화면</string>
+
+    <!-- self diagnosis test -->
+    <string name="self_diagnosis_test_PSS_title">스틀햇과 함께 하는 PSS 검사</string>
+    <string name="self_diagnosis_test_SRI_title">스틀햇과 함께 하는 SRI 검사</string>
+    <string name="self_diagnosis_test_PHQ_9_title">스틀햇과 함께 하는 PHQ-9 검사</string>
+    <string name="self_diagnosis_test_default_title">스틀햇과 함께 하는 자가진단 검사</string>
+    <string name="self_diagnosis_test_selection_description">1 : 전혀 그렇지 않다, 2 : 그렇지 않다,\n\n3: 보통이다, 4 : 그렇다, 5 : 매우 그렇다</string>
+    <string name="self_diagnosis_test_exit_button">검사 종료하기</string>
 
     <!-- self diagnosis result -->
     <string name="self_diagnosis_result_nickname_description">님의</string>


### PR DESCRIPTION
## Related issue 🛠
- closed #33  

## Work Description 📝
- 자가진단 테스트 뷰 구현
- 자가진단 데이터 조회 API 연동
- 자가진단 결과 저장 API 연동
- 자가진단 결과 조회 API 연동
- 주간 스트레스 변화 시각화 API 연동
- 주간 그래프 막대 클릭 시 해당 날짜의 스트레스 점수 확인, 피드백 조회 뷰 연결
- 일기 없는 주간 그래프 empty view 구현
- 오늘 스트레스 점수 확인 empty view 구현
- 마이페이지 스틀햇 이미지 비율 코딩, 스트레스 점수 & 수준 color 분기처리

## Screenshot 📸
https://github.com/user-attachments/assets/c4afd3dc-4a57-47a5-8e93-559ff6d099cc

https://github.com/user-attachments/assets/62ecb6a8-1463-4b29-968b-4044ac329297

https://github.com/user-attachments/assets/961c40bc-486f-4ad7-ad3a-1bd66fdb6e59

https://github.com/user-attachments/assets/6bc12b11-525a-4df9-9616-fbe58e920246


## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
자가진단, 스트레스 변화 시각화 API 연동 및 세세한 디테일 챙기는 작업 진행했습니다!

일기를 한번도 작성하지 않은 주간에 대한 empty view는 간단한 문구와 함께 추가하였고,
스트레스 & 감정 주간 그래프에서 막대 클릭 시 각각 스트레스 점수 확인 뷰, AI 피드백 조회 뷰로 연결되게끔 구현했습니다 :)

아직 오늘의 일기를 작성하지 않아서 스트레스 점수가 없을 때에 대한 empty view 또한 간단하게 디자인하여 구현했습니다 ~

그리고 아직 자가진단 기록 확인 쪽은 수정해야 할 부분들이 있는데, 그 부분은 다음 이슈에서 진행할게요! (#36)

cf) 쏭 솝커톤 화이팅 ㅎ.ㅎ